### PR TITLE
Paramref drawer (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2024-02-21
+### Added
+- Support for displaying only the correct sub class of ParameterScriptableObjects in Inspector
+
 ## [3.4.1] - 2023-12-18
 ### Added
 - More details in `README` about renaming fields.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pocketgems.scriptableobject.flatbuffer",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "displayName": "Scriptable Object - FlatBuffer",
   "description": "Seamless syncing between Scriptable Objects and CSVs.  Scriptable Object data built to Google FlatBuffers for optimal runtime loading & access.",
   "unity": "2021.3",


### PR DESCRIPTION
# Change Log
## [3.5.0] - 2024-02-21
### Added
- Support for displaying only the correct sub class of ParameterScriptableObjects in Inspector

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
