### PR TITLE
add support for building package as a standalone (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2024-04-30
+### Added
+- Support code for building the parameters runtime outside of Unity
+- `FilePathAssetLoader` for non Unity loading
+- Method `IBaseInfo Get(string identifier, Type type)` to the `ParameterManager` and `Params`
+
 ## [3.5.0] - 2024-02-21
 ### Added
 - Support for displaying only the correct sub class of ParameterScriptableObjects in Inspector

--- a/Editor/EditorParameterConstants.cs
+++ b/Editor/EditorParameterConstants.cs
@@ -18,7 +18,7 @@ namespace PocketGems.Parameters
         /// Ideally it would be the most convenient to use the package version but that requires file I/O to
         /// the package.json which can be costly if we're doing it all of the time.
         /// </summary>
-        public const string InterfaceHashSalt = "206d26c7-eaf9-4d6f-ad01-77187cc981a2";
+        public const string InterfaceHashSalt = "f1f48d2a-adc0-4ad8-b612-c70e076c35c9";
 
         public static string SanitizedDataPath()
         {

--- a/Runtime/AssetLoader/AddressablesParameterAssetLoader.cs
+++ b/Runtime/AssetLoader/AddressablesParameterAssetLoader.cs
@@ -1,4 +1,4 @@
-#if ADDRESSABLE_PARAMS
+#if ADDRESSABLE_PARAMS && UNITY_2021_3_OR_NEWER
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;

--- a/Runtime/AssetLoader/EditorAssetLoaderUtil.cs
+++ b/Runtime/AssetLoader/EditorAssetLoaderUtil.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace PocketGems.Parameters.AssetLoader
 {

--- a/Runtime/AssetLoader/FilePathAssetLoader.cs
+++ b/Runtime/AssetLoader/FilePathAssetLoader.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using UnityEngine;
+
+namespace PocketGems.Parameters.AssetLoader
+{
+    /// <summary>
+    /// Parameter loader that loads assets directly by path.
+    /// </summary>
+    public class FilePathAssetLoader : IParameterAssetLoader
+    {
+        /// <inheritdoc cref="IParameterAssetLoader.Status"/>
+        public ParameterAssetLoaderStatus Status { get; protected set; }
+
+        public static string DirectoryPath;
+
+        /// <summary>
+        /// Constructor for the asset loader.
+        /// </summary>
+        public FilePathAssetLoader()
+        {
+            Status = ParameterAssetLoaderStatus.NotStarted;
+        }
+
+        /// <inheritdoc cref="IParameterAssetLoader.LoadData"/>
+        public virtual void LoadData(IMutableParameterManager parameterManager, IParameterDataLoader parameterDataLoader)
+        {
+            Status = ParameterAssetLoaderStatus.Loading;
+
+            var resourceName = ParameterConstants.GeneratedAssetName + ParameterConstants.GeneratedParameterAssetFileExtension;
+            var filePath = resourceName;
+            if (!string.IsNullOrWhiteSpace(DirectoryPath))
+            {
+                filePath = Path.Combine(DirectoryPath, resourceName);
+            }
+            if (!File.Exists(filePath))
+            {
+                Debug.LogError($"Load data for IMutableParameterManager, cannot find parameter file {filePath}");
+                Status = ParameterAssetLoaderStatus.Failed;
+                return;
+            }
+            var bytes = File.ReadAllBytes(filePath);
+            parameterDataLoader.LoadData(parameterManager, bytes);
+            Status = ParameterAssetLoaderStatus.Loaded;
+        }
+    }
+}

--- a/Runtime/AssetLoader/FilePathAssetLoader.cs.meta
+++ b/Runtime/AssetLoader/FilePathAssetLoader.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 92927a5ac5794b54a45c364a45ef58e2
+timeCreated: 1712619927

--- a/Runtime/AssetLoader/ParameterAssetLoaderProvider.cs
+++ b/Runtime/AssetLoader/ParameterAssetLoaderProvider.cs
@@ -22,18 +22,20 @@ namespace PocketGems.Parameters.AssetLoader
         public static IParameterAssetLoader CreateParameterAssetLoader()
         {
 #if UNITY_EDITOR
-    #if ADDRESSABLE_PARAMS
+#if ADDRESSABLE_PARAMS
             RunningHotLoader = new EditorAddressablesParameterAssetLoader();
-    #else
-            RunningHotLoader = new EditorResourcesParameterAssetLoader();
-    #endif
-            return RunningHotLoader;
 #else
-    #if ADDRESSABLE_PARAMS
+            RunningHotLoader = new EditorResourcesParameterAssetLoader();
+#endif
+            return RunningHotLoader;
+#elif UNITY_2021_3_OR_NEWER
+#if ADDRESSABLE_PARAMS
             return new AddressablesParameterAssetLoader();
-    #else
+#else
             return new ResourcesParameterAssetLoader();
-    #endif
+#endif
+#else
+            return new FilePathAssetLoader();
 #endif
         }
     }

--- a/Runtime/AssetLoader/ResourcesParameterAssetLoader.cs
+++ b/Runtime/AssetLoader/ResourcesParameterAssetLoader.cs
@@ -1,3 +1,4 @@
+#if UNITY_2021_3_OR_NEWER
 using System.IO;
 using UnityEngine;
 
@@ -52,3 +53,4 @@ namespace PocketGems.Parameters.AssetLoader
         }
     }
 }
+#endif

--- a/Runtime/IParameterManager.cs
+++ b/Runtime/IParameterManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using PocketGems.Parameters.Interface;
 
@@ -15,6 +16,14 @@ namespace PocketGems.Parameters
         /// <typeparam name="T">type to query</typeparam>
         /// <returns>the parameter if it exists</returns>
         T Get<T>(string identifier) where T : class, IBaseInfo;
+
+        /// <summary>
+        /// Get a particular parameter object by identifier.
+        /// </summary>
+        /// <param name="type">type of object to return. This is expected to be a subinterface of IBaseInfo</param>
+        /// <param name="identifier">identifier to query</param>
+        /// <returns>object of type IBaseInfo, and implicitly of type Type</returns>
+        IBaseInfo Get(string identifier, Type type);
 
         /// <summary>
         /// Get a particular parameter object by guid.

--- a/Runtime/ParameterConstants.cs
+++ b/Runtime/ParameterConstants.cs
@@ -32,6 +32,11 @@ namespace PocketGems.Parameters
         /// </summary>
         public const string GeneratedResourceDirectory = "GeneratedParameterData";
 
+        /// <summary>
+        /// File type used to store the FlatBuffer byte file.  Used at both runtime & in the editor assembly.
+        /// </summary>
+        internal const string GeneratedParameterAssetFileExtension = ".bytes";
+
 #if ADDRESSABLE_PARAMS
         public static class Addressables
         {
@@ -53,11 +58,6 @@ namespace PocketGems.Parameters
             public static string Dir => Path.Combine(Folders);
         }
 
-        /// <summary>
-        /// File type used to store the FlatBuffer byte file.  Used at both runtime & in the editor assembly.
-        /// </summary>
-        internal const string GeneratedParameterAssetFileExtension = ".bytes";
-
         internal static class GeneratedAsset
         {
             /// <summary>
@@ -72,11 +72,11 @@ namespace PocketGems.Parameters
             {
                 get
                 {
-    #if ADDRESSABLE_PARAMS
+#if ADDRESSABLE_PARAMS
                     const string folderName = "Assets";
-    #else
+#else
                     const string folderName = "Resources";
-    #endif
+#endif
                     var intermediateFolder = Path.Combine(RootDirectory, folderName);
                     return Path.Combine(intermediateFolder, GeneratedResourceDirectory);
                 }

--- a/Runtime/ParameterManager.cs
+++ b/Runtime/ParameterManager.cs
@@ -256,6 +256,12 @@ namespace PocketGems.Parameters
             guidDict[guid] = parameter;
         }
 
+        public IBaseInfo Get(string identifier, Type type)
+        {
+            CheckGet();
+            return (IBaseInfo)Get(type, identifier);
+        }
+
         private IMutableParameter Get(Type type, string identifier)
         {
             if (type == typeof(IBaseInfo))

--- a/Runtime/Params.cs
+++ b/Runtime/Params.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using PocketGems.Parameters.Interface;
 using UnityEngine;
@@ -21,6 +22,8 @@ namespace PocketGems.Parameters
         public static T Get<T>(string identifier) where T : class, IBaseInfo => s_parameterManager.Get<T>(identifier);
 
         public static T GetWithGUID<T>(string guid) where T : class, IBaseInfo => s_parameterManager.GetWithGUID<T>(guid);
+
+        public static IBaseInfo Get(string identifier, Type type) => s_parameterManager.Get(identifier, type);
 
         public static IEnumerable<T> Get<T>() where T : class, IBaseInfo => s_parameterManager.Get<T>();
 

--- a/Tests/Editor/TestAssemblies/TestGeneratedCodeEditorAssembly/TestGeneratedCodeEditorAssembly.asmdef
+++ b/Tests/Editor/TestAssemblies/TestGeneratedCodeEditorAssembly/TestGeneratedCodeEditorAssembly.asmdef
@@ -1,7 +1,13 @@
 {
     "name": "TestGeneratedCodeEditorAssembly",
     "rootNamespace": "",
-    "references": ["GUID:343deaaf83e0cee4ca978e7df0b80d21","GUID:2bafac87e7f4b9b418d9448d219b01ab","GUID:0acc523941302664db1f4e527237feb3","GUID:27619889b8ba8c24980f49ee34dbb44a","GUID:afd70ab7f8472492bbd5e6dce8ab1336"],
+    "references": [
+        "GUID:343deaaf83e0cee4ca978e7df0b80d21",
+        "GUID:2bafac87e7f4b9b418d9448d219b01ab",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:afd70ab7f8472492bbd5e6dce8ab1336"
+    ],
     "includePlatforms": [
         "Editor"
     ],

--- a/Tests/Runtime/AssetLoader/FilePathAssetLoaderTest.cs
+++ b/Tests/Runtime/AssetLoader/FilePathAssetLoaderTest.cs
@@ -1,0 +1,12 @@
+namespace PocketGems.Parameters.AssetLoader
+{
+    public class FilePathAssetLoaderTest : BaseParameterAssetLoaderTest
+    {
+        protected override IParameterAssetLoader CreateParameterAssetLoader()
+        {
+            var loader = new FilePathAssetLoader();
+            FilePathAssetLoader.DirectoryPath = TestDirectoryPath;
+            return loader;
+        }
+    }
+}

--- a/Tests/Runtime/AssetLoader/FilePathAssetLoaderTest.cs.meta
+++ b/Tests/Runtime/AssetLoader/FilePathAssetLoaderTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 44cacae8817a4f6681934564b020b612
+timeCreated: 1714523298

--- a/Tests/Runtime/ParameterManagerTest.cs
+++ b/Tests/Runtime/ParameterManagerTest.cs
@@ -54,9 +54,13 @@ namespace PocketGems.Parameters
         {
             Assert.IsNull(_pm.Get<IMySpecialInfo>(SpecialId));
             Assert.IsNull(_pm.Get<IMyVerySpecialInfo>(SpecialId));
+            Assert.IsNull(_pm.Get(SpecialId, typeof(IMySpecialInfo)));
+            Assert.IsNull(_pm.Get(SpecialId, typeof(IMyVerySpecialInfo)));
 
             Assert.IsNull(_pm.Get<IMySpecialInfo>(VerySpecialId));
             Assert.IsNull(_pm.Get<IMyVerySpecialInfo>(VerySpecialId));
+            Assert.IsNull(_pm.Get(VerySpecialId, typeof(IMySpecialInfo)));
+            Assert.IsNull(_pm.Get(VerySpecialId, typeof(IMyVerySpecialInfo)));
 
             LogAssert.Expect(LogType.Error, new Regex(".*"));
             Assert.IsNull(_pm.GetWithGUID<IMySpecialInfo>(SpecialGuid));
@@ -79,8 +83,12 @@ namespace PocketGems.Parameters
             LoadInfos();
 
             Assert.AreEqual(_mockMySpecialInfo, _pm.Get<IMySpecialInfo>(SpecialId));
+            Assert.AreEqual(_mockMySpecialInfo, _pm.Get(SpecialId, typeof(IMySpecialInfo)));
             Assert.IsNull(_pm.Get<IMyVerySpecialInfo>(SpecialId));
+            Assert.IsNull(_pm.Get(SpecialId, typeof(IMyVerySpecialInfo)));
 
+            Assert.AreEqual(_mockMyVerySpecialInfo, _pm.Get(VerySpecialId, typeof(IMySpecialInfo)));
+            Assert.AreEqual(_mockMyVerySpecialInfo, _pm.Get(VerySpecialId, typeof(IMyVerySpecialInfo)));
             Assert.AreEqual(_mockMyVerySpecialInfo, _pm.Get<IMySpecialInfo>(VerySpecialId));
             Assert.AreEqual(_mockMyVerySpecialInfo, _pm.Get<IMyVerySpecialInfo>(VerySpecialId));
 
@@ -179,6 +187,7 @@ namespace PocketGems.Parameters
             LoadInfos();
 
             Assert.AreEqual(_mockMyVerySpecialInfo, _pm.Get<IMySpecialInfo>(VerySpecialId));
+            Assert.AreEqual(_mockMyVerySpecialInfo, _pm.Get(VerySpecialId, typeof(IMySpecialInfo)));
             Assert.AreEqual(_mockMyVerySpecialInfo, _pm.GetWithGUID<IMySpecialInfo>(VerySpecialGuid));
             Assert.AreEqual(_mockKeyValueStruct, _pm.GetStructWithGuid<IKeyValueStruct>(StructGuid));
 
@@ -192,6 +201,7 @@ namespace PocketGems.Parameters
             _pm.Load<IKeyValueStruct, MockKeyValueStruct>(newStruct, StructGuid);
 
             Assert.AreEqual(newInfo, _pm.Get<IMySpecialInfo>(VerySpecialId));
+            Assert.AreEqual(newInfo, _pm.Get(VerySpecialId, typeof(IMySpecialInfo)));
             Assert.AreEqual(newInfo, _pm.GetWithGUID<IMySpecialInfo>(VerySpecialGuid));
             Assert.AreEqual(newStruct, _pm.GetStructWithGuid<IKeyValueStruct>(StructGuid));
 
@@ -434,6 +444,9 @@ namespace PocketGems.Parameters
             LogAssert.Expect(LogType.Error, regex);
             Assert.IsNull(_pm.Get<IMySpecialInfo>(SpecialId));
             Assert.IsTrue(_pm.HasGetBeenCalled);
+
+            LogAssert.Expect(LogType.Error, regex);
+            Assert.IsNull(_pm.Get(SpecialId, typeof(IMySpecialInfo)));
 
             LogAssert.Expect(LogType.Error, regex);
             Assert.IsEmpty(_pm.Get<IMySpecialInfo>());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pocketgems.scriptableobject.flatbuffer",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "displayName": "Scriptable Object - FlatBuffer",
   "description": "Seamless syncing between Scriptable Objects and CSVs.  Scriptable Object data built to Google FlatBuffers for optimal runtime loading & access.",
   "unity": "2021.3",


### PR DESCRIPTION
# Change Log
## [3.6.0] - 2024-04-30
### Added
- Support code for building the parameters runtime outside of Unity
- `FilePathAssetLoader` for non Unity loading
- Method `IBaseInfo Get(string identifier, Type type)` to the `ParameterManager` and `Params`

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
