### PR TITLE
fix assembly name used in param ref drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.1] - 2024-05-03
+### Fixed
+- Fix assembly name used in parameter reference drawer
+
 ## [3.7.0] - 2024-05-03
 ### Added
 - Ordering in the Scriptable Object create asset menu.

--- a/Editor/Editor/ParameterReferenceDrawer.cs
+++ b/Editor/Editor/ParameterReferenceDrawer.cs
@@ -327,7 +327,7 @@ namespace PocketGems.Parameters.Editor
         /// <param name="interfaceType">Interface type of the parameter</param>
         private Type GetImplementingType(Type interfaceType)
         {
-            Assembly assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == EditorParameterConstants.GeneratedCode.AssemblyName);
+            Assembly assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == EditorParameterConstants.GeneratedCode.EditorAssemblyName);
 
             Type[] types = assembly.GetTypes();
             int implementingTypes = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pocketgems.scriptableobject.flatbuffer",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "displayName": "Scriptable Object - FlatBuffer",
   "description": "Seamless syncing between Scriptable Objects and CSVs.  Scriptable Object data built to Google FlatBuffers for optimal runtime loading & access.",
   "unity": "2021.3",


### PR DESCRIPTION
# Change Log
## [3.7.1] - 2024-05-03
### Fixed
- Fix assembly name used in parameter reference drawer 

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
