### PR TITLE
increase parameter drawer depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.1] - 2024-05-10
+### Fixed
+- `ParameterScriptableObject` drawer depth limitation removed to blocking drawers from opening.
+
 ## [3.8.0] - 2024-05-07
 ### Changed
 - Replaced FileAssetLoader with EmbeddedResourceAssetLoader for Non-Unity environment

--- a/Editor/Editor/ParameterReferenceDrawer.cs
+++ b/Editor/Editor/ParameterReferenceDrawer.cs
@@ -26,12 +26,14 @@ namespace PocketGems.Parameters.Editor
     public class ParameterReferenceDrawer : PropertyDrawer
     {
         /*
-         * Only allow the fold out to be at the top most depth.
+         * Only allow the fold out to be at the top most depth. (MaxDepth 1)
          * Unity starts getting real buggy visually when nesting too many GUI layers
          * (low ROI to handle all depths & corner cases).
+         *
+         * Note: It was set to 1 originally but increased to 10 for now.
          */
+        private const int MaxDepth = 10;
         private static int s_depthCounter = 0;
-        private const int MaxDepth = 1;
 
         /*
          * This is needed so we do not attempt to work around a Unity issue.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pocketgems.scriptableobject.flatbuffer",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "displayName": "Scriptable Object - FlatBuffer",
   "description": "Seamless syncing between Scriptable Objects and CSVs.  Scriptable Object data built to Google FlatBuffers for optimal runtime loading & access.",
   "unity": "2021.3",


### PR DESCRIPTION
# Change Log
## [3.8.1] - 2024-05-10
### Fixed
- `ParameterScriptableObject` drawer depth limitation removed to blocking drawers from opening.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
