### PR TITLE
make parameter struct reference thread safe 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.5] - 2024-05-28
+### Fixed
+- `ParameterStructReference<>.Struct` to be thread safe.
+
 ## [3.8.4] - 2024-05-22
 ### Fixed
 - `ParameterReference<>.Info` to be thread safe.

--- a/Runtime/ParameterStructReference.cs
+++ b/Runtime/ParameterStructReference.cs
@@ -1,5 +1,9 @@
 using PocketGems.Parameters.Interface;
 using UnityEngine;
+#if UNITY_EDITOR
+using System.Threading;
+using UnityEditor;
+#endif
 
 namespace PocketGems.Parameters
 {
@@ -24,8 +28,12 @@ namespace PocketGems.Parameters
             get
             {
 #if UNITY_EDITOR
-                if (!Application.isPlaying)
+                // We allow the Info to be used in the background at runtime.
+                // Calling Application.isPlaying causes issues in the background.
+                if (Thread.CurrentThread.ManagedThreadId == 1 && !Application.isPlaying)
+                {
                     return GetStruct(EditorParams.ParameterManager);
+                }
 #endif
                 if (Params.ParameterManager == null)
                 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pocketgems.scriptableobject.flatbuffer",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "displayName": "Scriptable Object - FlatBuffer",
   "description": "Seamless syncing between Scriptable Objects and CSVs.  Scriptable Object data built to Google FlatBuffers for optimal runtime loading & access.",
   "unity": "2021.3",


### PR DESCRIPTION
## [3.8.5] - 2024-05-28
### Fixed
- `ParameterStructReference<>.Struct` to be thread safe.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
