### PR TITLE
3.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.6] - 2024-06-06
+### Fixed
+- Missing `using` for `DateTime` & `TimeSpan` usage in structs
+
 ## [3.8.5] - 2024-05-28
 ### Fixed
 - `ParameterStructReference<>.Struct` to be thread safe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.8.6] - 2024-06-06
 ### Fixed
 - Missing `using` for `DateTime` & `TimeSpan` usage in structs
+- `DateTime` & `TimeSpan` drawer rendering when nested in structs
 
 ## [3.8.5] - 2024-05-28
 ### Fixed

--- a/Editor/Editor/SerializableDateTimeDrawer.cs
+++ b/Editor/Editor/SerializableDateTimeDrawer.cs
@@ -19,10 +19,12 @@ namespace PocketGems.Parameters.Editor
             var labelWidth = EditorGUIUtility.labelWidth + 20.0f;
             rect.x = labelWidth;
 
-            const float componentLabelPadding = 4.0f;
+            const float componentLabelPadding = 2.0f;
             var floatFieldStyle = new GUIStyle(GUI.skin.textField);
             float digitWidth = EditorStyles.label.CalcSize(new GUIContent("0")).x * 1.5f;
             floatFieldStyle.alignment = TextAnchor.MiddleRight;
+            floatFieldStyle.padding = new RectOffset();
+            floatFieldStyle.margin = new RectOffset();
 
             int DrawComponent(string componentLabel, int componentDigits, int componentValue)
             {
@@ -33,7 +35,10 @@ namespace PocketGems.Parameters.Editor
 
                 var componentLabelWidth = EditorStyles.label.CalcSize(new GUIContent(componentLabel)).x;
                 rect.width = componentLabelWidth;
-                EditorGUI.LabelField(rect, componentLabel);
+                GUIStyle labelStyle = GUI.skin.label;
+                labelStyle.padding = new RectOffset();
+                labelStyle.margin = new RectOffset();
+                GUI.Label(rect, componentLabel, labelStyle);
                 rect.x += componentLabelWidth + componentLabelPadding;
 
                 return intComponentValue;

--- a/Editor/Editor/SerializableTimeSpanDrawer.cs
+++ b/Editor/Editor/SerializableTimeSpanDrawer.cs
@@ -19,10 +19,12 @@ namespace PocketGems.Parameters.Editor
             var labelWidth = EditorGUIUtility.labelWidth + 20.0f;
             rect.x = labelWidth;
 
-            const float componentLabelPadding = 4.0f;
+            const float componentLabelPadding = 2.0f;
             var floatFieldStyle = new GUIStyle(GUI.skin.textField);
             float digitWidth = EditorStyles.label.CalcSize(new GUIContent("0")).x * 1.5f;
             floatFieldStyle.alignment = TextAnchor.MiddleRight;
+            floatFieldStyle.padding = new RectOffset();
+            floatFieldStyle.margin = new RectOffset();
 
             float DrawComponent(string componentLabel, int componentDigits, int componentValue)
             {
@@ -33,7 +35,10 @@ namespace PocketGems.Parameters.Editor
 
                 var componentLabelWidth = EditorStyles.label.CalcSize(new GUIContent(componentLabel)).x;
                 rect.width = componentLabelWidth;
-                EditorGUI.LabelField(rect, componentLabel);
+                GUIStyle labelStyle = GUI.skin.label;
+                labelStyle.padding = new RectOffset();
+                labelStyle.margin = new RectOffset();
+                GUI.Label(rect, componentLabel, labelStyle);
                 rect.x += componentLabelWidth + componentLabelPadding;
 
                 return floatComponentValue;

--- a/Editor/EditorParameterConstants.cs
+++ b/Editor/EditorParameterConstants.cs
@@ -18,7 +18,7 @@ namespace PocketGems.Parameters
         /// Ideally it would be the most convenient to use the package version but that requires file I/O to
         /// the package.json which can be costly if we're doing it all of the time.
         /// </summary>
-        public const string InterfaceHashSalt = "383a77c7-da21-469c-880d-d8aa0a64faf2";
+        public const string InterfaceHashSalt = "7e10aadc-9b6c-41a7-9c7e-ee672e5a21c8";
 
         public static string SanitizedDataPath()
         {

--- a/Editor/Templates/Struct.template
+++ b/Editor/Templates/Struct.template
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using PocketGems.Parameters;
+using PocketGems.Parameters.DataTypes;
 using PocketGems.Parameters.Interface;
 using PocketGems.Parameters.Types;
 using PocketGems.Parameters.Validation;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pocketgems.scriptableobject.flatbuffer",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "displayName": "Scriptable Object - FlatBuffer",
   "description": "Seamless syncing between Scriptable Objects and CSVs.  Scriptable Object data built to Google FlatBuffers for optimal runtime loading & access.",
   "unity": "2021.3",


### PR DESCRIPTION
## [3.8.6] - 2024-06-06
### Fixed
- Missing `using` for `DateTime` & `TimeSpan` usage in structs
- `DateTime` & `TimeSpan` drawer rendering when nested in structs

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
