### PR TITLE
fix issue with running validation during editor play 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2024-10-07
+### Fixed
+- Issue where validation is ran on the Scriptable Object inspector while the editor is playing and parameter manager isn't set up.
+
 ## [4.0.0] - 2024-07-17
 ### Changed
 - Editor code organization to support external code generation.

--- a/Editor/Editor/ParameterScriptableObjectInspector.cs
+++ b/Editor/Editor/ParameterScriptableObjectInspector.cs
@@ -97,14 +97,25 @@ namespace PocketGems.Parameters.Editor.Editor
             DrawParameterToolGUI();
 
             ValidationError[] validationErrors = null;
-            try
+            if (Application.isPlaying && Params.ParameterManager == null)
             {
-                validationErrors = ((ParameterScriptableObject)target).ValidationErrors();
+                /*
+                 * the game is probably still being set up so do not run validation at this time since it may
+                 * break due to missing parameter manager when accessing parameter references.
+                 */
+                EditorGUILayout.HelpBox("Validation is disabled at this time.", MessageType.Warning);
             }
-            catch (Exception e)
+            else
             {
-                // catch and report errors so that users aren't completely stuck on modifying the object
-                Debug.LogError(e);
+                try
+                {
+                    validationErrors = ((ParameterScriptableObject)target).ValidationErrors();
+                }
+                catch (Exception e)
+                {
+                    // catch and report errors so that users aren't completely stuck on modifying the object
+                    Debug.LogError(e);
+                }
             }
 
             // construct error mappings property name -> errors

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pocketgems.scriptableobject.flatbuffer",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "displayName": "Scriptable Object - FlatBuffer",
   "description": "Seamless syncing between Scriptable Objects and CSVs.  Scriptable Object data built to Google FlatBuffers for optimal runtime loading & access.",
   "unity": "2021.3",


### PR DESCRIPTION
## [4.0.1] - 2024-10-07
### Fixed
- Issue where validation is ran on the Scriptable Object inspector while the editor is playing and parameter manager isn't set up.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
