### PR TITLE
update the version key location in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.2] - 2025-12-24
+### Changed
+- Moved the version key in the `package.json` to a different location.
+
 ## [4.6.1] - 2025-12-24
 ### Changed
 - MenuItem code is code generated in one file to reduce git diffs when an info is added/removed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "com.pocketgems.scriptableobject.flatbuffer",
-  "version": "4.6.1",
   "displayName": "Scriptable Object - FlatBuffer",
   "description": "Seamless syncing between Scriptable Objects and CSVs.  Scriptable Object data built to Google FlatBuffers for optimal runtime loading & access.",
   "unity": "2021.3",
@@ -16,6 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
+  "version": "4.6.2",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [4.6.2] - 2025-12-24
### Changed
- Moved the version key in the `package.json` to a different location.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
