### PR TITLE
5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - 2026-03-25
+### Changed
+- Reduced the memory foot print of InfoFlatBuffer instances.
+
 ## [5.0.0] - 2026-02-06
 ### Added
 - `TryGet<T>()` method to `IParameterManager` and `Params`

--- a/Editor/CodeGeneration/Util/CodeGenerator.cs
+++ b/Editor/CodeGeneration/Util/CodeGenerator.cs
@@ -286,15 +286,10 @@ namespace PocketGems.Parameters.CodeGeneration.Util.Editor
                     propertyTypeDict["fieldDefinitionCode"] = fieldDefinition;
 
                 // property implementation
-                propertyTypeDict["propertyImplementationCode"] = propertyType.FlatBufferPropertyImplementationCode();
+                propertyTypeDict["propertyImplementationCode"] = propertyType.FlatBufferPropertyImplementationCode(i);
 
                 // edit property
-                propertyTypeDict["editPropertyCode"] = propertyType.FlatBufferEditPropertyCode("value");
-
-                // remove edit property
-                var removeEdit = propertyType.FlatBufferRemoveEditCode();
-                if (!string.IsNullOrWhiteSpace(removeEdit))
-                    propertyTypeDict["removeEditCode"] = removeEdit;
+                propertyTypeDict["editPropertyCode"] = propertyType.FlatBufferEditPropertyCode(i, propertyTypes.Count, "value");
             }
 
             var args = new Dictionary<string, object>
@@ -307,7 +302,8 @@ namespace PocketGems.Parameters.CodeGeneration.Util.Editor
                 { "interfaceName", parameterInterface.InterfaceName },
                 { "flatBufferStructName", parameterInterface.FlatBufferStructName(false) },
                 { "propertyTypeDicts", propertyTypeDicts },
-                { "parameterManagerType", nameof(IParameterManager) },
+                { "baseClassName", nameof(BaseInfoFlatBuffer) },
+                { "parameterManagerType", nameof(IParameterManager) }
             };
             var fileName = parameterInterface.FlatBufferClassName(true);
             var filePath = Path.Combine(outputDirectory, fileName);

--- a/Editor/Common/EditorParameterConstants.cs
+++ b/Editor/Common/EditorParameterConstants.cs
@@ -18,7 +18,7 @@ namespace PocketGems.Parameters.Common.Editor
         /// Ideally it would be the most convenient to use the package version but that requires file I/O to
         /// the package.json which can be costly if we're doing it all of the time.
         /// </summary>
-        public const string InterfaceHashSalt = "01622d58-770d-4cc0-a581-d8f2be075d29";
+        public const string InterfaceHashSalt = "aa9a175c-e1b9-4cab-bcb0-648ea1853c63";
 
         public static string SanitizedDataPath()
         {

--- a/Editor/Common/PropertyTypes/AssetReferenceListPropertyType.cs
+++ b/Editor/Common/PropertyTypes/AssetReferenceListPropertyType.cs
@@ -21,17 +21,14 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public IReadOnlyList<{ClassName}> {PropertyName} => {FieldName};";
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {ClassName}[] {OverrideFieldName};";
-
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             return $"public IReadOnlyList<{ClassName}> {PropertyName}\n" +
                    $"{{\n" +
                    $"    get\n" +
                    $"    {{\n" +
-                   $"        if ({OverrideFieldName} != null)\n" +
-                   $"            return {OverrideFieldName};\n" +
+                   $"        if (TryGetOverride<{ClassName}[]>({propertyIndex}, out var val))\n" +
+                   $"            return val;\n" +
                    $"        return new ReadOnlyListContainer<{ClassName}>(\n" +
                    $"            () => _fb.{FlatBufferStructPropertyName}Length,\n" +
                    $"            i =>\n" +
@@ -48,11 +45,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
 
         // no need to set validateGuid to true in the this call to FromString - the check only checks the AssetDatabase in editor.
         // Also, this check an potentially give false positive if the asset is a new asset from an addresss catalog we're ab testing in.
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {nameof(CSVValueConverter)}.{ClassName}Array.FromString({variableName});";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{ClassName}[]>({propertyIndex}, {nameof(CSVValueConverter)}.{ClassName}Array.FromString({variableName}), {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName)
         {

--- a/Editor/Common/PropertyTypes/AssetReferencePropertyType.cs
+++ b/Editor/Common/PropertyTypes/AssetReferencePropertyType.cs
@@ -21,18 +21,14 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public {ClassName} {PropertyName} => {FieldName};";
 
-
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {ClassName} {OverrideFieldName};";
-
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             return $"public {ClassName} {PropertyName}\n" +
                    $"{{\n" +
                    $"    get\n" +
                    $"    {{\n" +
-                   $"        if ({OverrideFieldName} != null)\n" +
-                   $"            return {OverrideFieldName};\n" +
+                   $"        if (TryGetOverride<{ClassName}>({propertyIndex}, out var val))\n" +
+                   $"            return val;\n" +
                    $"        var assetRef = new {ClassName}(_fb.{FlatBufferStructPropertyName});\n" +
                    $"        var subObjectName = _fb.{SubObjectNameFlatBufferStructPropertyName};\n" +
                    $"        if (!string.IsNullOrEmpty(subObjectName))\n" +
@@ -44,11 +40,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
 
         // no need to set validateGuid to true in the this call to FromString - the check only checks the AssetDatabase in editor.
         // Also, this check an potentially give false positive if the asset is a new asset from an addresss catalog we're ab testing in.
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {nameof(CSVValueConverter)}.{ClassName}.FromString({variableName});";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{ClassName}>({propertyIndex}, {nameof(CSVValueConverter)}.{ClassName}.FromString({variableName}), {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName)
         {

--- a/Editor/Common/PropertyTypes/BasePropertyType.cs
+++ b/Editor/Common/PropertyTypes/BasePropertyType.cs
@@ -84,10 +84,9 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
             string localizationKeysArgumentName,
             string localizedScriptArgumentName) => null;
 
-        public abstract string FlatBufferFieldDefinitionCode();
-        public abstract string FlatBufferPropertyImplementationCode();
-        public abstract string FlatBufferEditPropertyCode(string variableName);
-        public abstract string FlatBufferRemoveEditCode();
+        public virtual string FlatBufferFieldDefinitionCode() => null;
+        public abstract string FlatBufferPropertyImplementationCode(int propertyIndex);
+        public abstract string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName);
 
         public abstract string FlatBufferBuilderPrepareCode(string tableName);
         public abstract string FlatBufferBuilderCode(string tableName);
@@ -105,7 +104,6 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         // helper methods
         protected string PropertyName => PropertyInfo.Name;
         protected string PropertyTypeName => PropertyInfo.PropertyType.Name;
-        protected string OverrideFieldName => $"_override{PropertyInfo.Name}";
         protected string FieldName => $"_{PropertyInfo.Name.LowercaseFirstChar()}";
         protected string FlatBufferStructPropertyName => PropertyInfo.Name.UppercaseFirstChar();
     }

--- a/Editor/Common/PropertyTypes/BaseTimePropertyType.cs
+++ b/Editor/Common/PropertyTypes/BaseTimePropertyType.cs
@@ -16,8 +16,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectFieldDefinitionCode() =>
             $"public {SerializedType()} {FieldName};";
 
-        public override string FlatBufferPropertyImplementationCode() =>
-            $"public {PropertyTypeName} {PropertyName} => {OverrideFieldName} ?? new {PropertyTypeName}(_fb.{FlatBufferStructPropertyName});";
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex) =>
+            $"public {PropertyTypeName} {PropertyName} => TryGetOverride<{PropertyTypeName}>({propertyIndex}, out var val) ? val : new {PropertyTypeName}(_fb.{FlatBufferStructPropertyName});";
 
         public override string FlatBufferBuilderCode(string tableName) =>
             $"{tableName}.Add{FlatBufferStructPropertyName}(_builder, data.{PropertyName}.Ticks);";

--- a/Editor/Common/PropertyTypes/ColorPropertyType.cs
+++ b/Editor/Common/PropertyTypes/ColorPropertyType.cs
@@ -6,10 +6,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
 {
     internal class ColorPropertyType : BasePropertyType, IPropertyType
     {
-        public ColorPropertyType(PropertyInfo propertyInfo) : base(propertyInfo)
-        {
-
-        }
+        public ColorPropertyType(PropertyInfo propertyInfo) : base(propertyInfo) { }
 
         public override string ScriptableObjectFieldDefinitionCode() =>
             $"public Color {FieldName};";
@@ -17,17 +14,11 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public Color {PropertyName} => {FieldName};";
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private Color? {OverrideFieldName};";
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex) =>
+            $"public Color {PropertyName} => TryGetOverride<Color>({propertyIndex}, out var val) ? val : new Color(_fb.{fbPropertyR}, _fb.{fbPropertyG}, _fb.{fbPropertyB}, _fb.{fbPropertyA});";
 
-        public override string FlatBufferPropertyImplementationCode() =>
-            $"public Color {PropertyName} => {OverrideFieldName} ?? new Color(_fb.{fbPropertyR}, _fb.{fbPropertyG}, _fb.{fbPropertyB}, _fb.{fbPropertyA});";
-
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {FromStringCode(variableName)};";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<Color>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName) => null;
 

--- a/Editor/Common/PropertyTypes/EnumListPropertyType.cs
+++ b/Editor/Common/PropertyTypes/EnumListPropertyType.cs
@@ -29,14 +29,14 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
             return false;
         }
 
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             return $"public IReadOnlyList<{_typeKeyword}> {PropertyName}\n" +
                    $"{{\n" +
                    $"    get\n" +
                    $"    {{\n" +
-                   $"        if ({OverrideFieldName} != null)\n" +
-                   $"            return {OverrideFieldName};\n" +
+                   $"        if (TryGetOverride<{_typeKeyword}[]>({propertyIndex}, out var val))\n" +
+                   $"            return val;\n" +
                    $"        return new ReadOnlyListContainer<{_typeKeyword}>(\n" +
                    $"            () => _fb.{FlatBufferStructPropertyName}Length,\n" +
                    $"            i => ({_typeKeyword})_fb.{FlatBufferStructPropertyName}(i));\n" +

--- a/Editor/Common/PropertyTypes/EnumPropertyType.cs
+++ b/Editor/Common/PropertyTypes/EnumPropertyType.cs
@@ -10,8 +10,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         {
         }
 
-        public override string FlatBufferPropertyImplementationCode() =>
-            $"public {PropertyTypeName} {PropertyName} => {OverrideFieldName} ?? ({PropertyTypeName})_fb.{FlatBufferStructPropertyName};";
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex) =>
+            $"public {PropertyTypeName} {PropertyName} => TryGetOverride<{PropertyTypeName}>({propertyIndex}, out var val) ? val : ({PropertyTypeName})_fb.{FlatBufferStructPropertyName};";
 
         public override string FlatBufferBuilderCode(string tableName) =>
             $"{tableName}.Add{FlatBufferStructPropertyName}(_builder, (long)data.{PropertyName});";

--- a/Editor/Common/PropertyTypes/IPropertyType.cs
+++ b/Editor/Common/PropertyTypes/IPropertyType.cs
@@ -21,9 +21,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
 
         // flat buffer class interface implementation code
         string FlatBufferFieldDefinitionCode();
-        string FlatBufferPropertyImplementationCode();
-        string FlatBufferEditPropertyCode(string variableName);
-        string FlatBufferRemoveEditCode();
+        string FlatBufferPropertyImplementationCode(int propertyIndex);
+        string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName);
 
         // FlatBufferBuilder code generation
         string FlatBufferBuilderPrepareCode(string tableName);

--- a/Editor/Common/PropertyTypes/IdentifierPropertyType.cs
+++ b/Editor/Common/PropertyTypes/IdentifierPropertyType.cs
@@ -20,16 +20,13 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
             $"public {_typeKeyword} {PropertyName} => name;";
 
         public override string FlatBufferFieldDefinitionCode() =>
-            "// cached identifier\n" +
-            $"private string {CachedFieldName};";
+            $"private string {CachedFieldName}; // cached identifier";
 
-        public override string FlatBufferPropertyImplementationCode() =>
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex) =>
             $"public {_typeKeyword} {PropertyName} => {CachedFieldName} ??= _fb.{FlatBufferStructPropertyName};";
 
-        public override string FlatBufferEditPropertyCode(string variableName) =>
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
             $"throw new Exception(\"Cannot edit {PropertyName}.\");";
-
-        public override string FlatBufferRemoveEditCode() => null;
 
         public override string CSVBridgeReadFromCSVCode(string variableName)
         {

--- a/Editor/Common/PropertyTypes/NDimensionListPropertyType.cs
+++ b/Editor/Common/PropertyTypes/NDimensionListPropertyType.cs
@@ -24,10 +24,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public IReadOnlyList<{_typeKeyword}> {PropertyName} => {FieldName};";
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {_typeKeyword}[] {OverrideFieldName};";
-
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             int dimensions = ObjectFieldNames().Length;
             StringBuilder s = new StringBuilder();
@@ -35,8 +32,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
                      $"{{\n" +
                      $"    get\n" +
                      $"    {{\n" +
-                     $"        if ({OverrideFieldName} != null)\n" +
-                     $"            return {OverrideFieldName};\n" +
+                     $"        if (TryGetOverride<{_typeKeyword}[]>({propertyIndex}, out var val))\n" +
+                     $"            return val;\n" +
                      $"        return new ReadOnlyListContainer<{_typeKeyword}>(\n" +
                      $"            () => _fb.{FlatBufferStructPropertyName}Length / {dimensions},\n");
             s.Append($"            i =>\n" +
@@ -56,11 +53,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
             return s.ToString();
         }
 
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {FromStringCode(variableName)};";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{_typeKeyword}[]>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName)
         {

--- a/Editor/Common/PropertyTypes/ParameterReferenceListPropertyType.cs
+++ b/Editor/Common/PropertyTypes/ParameterReferenceListPropertyType.cs
@@ -40,16 +40,16 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public IReadOnlyList<ParameterReference<{_genericType.Name}>> {PropertyName} => {FieldName};";
 
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             return $"public IReadOnlyList<ParameterReference<{_genericType.Name}>> {PropertyName}\n" +
                    $"{{\n" +
                    $"    get\n" +
                    $"    {{\n" +
-                   $"        if ({OverrideFieldName} != null)\n" +
+                   $"        if (TryGetOverride<string[]>({propertyIndex}, out var val))\n" +
                    $"            return new ReadOnlyListContainer<ParameterReference<{_genericType.Name}>>(\n" +
-                   $"                () => {OverrideFieldName}.Length,\n" +
-                   $"                i => new ParameterReference<{_genericType.Name}>(_parameterManager, {OverrideFieldName}[i], true));\n" +
+                   $"                () => val.Length,\n" +
+                   $"                i => new ParameterReference<{_genericType.Name}>(_parameterManager, val[i], true));\n" +
                    $"        return new ReadOnlyListContainer<ParameterReference<{_genericType.Name}>>(\n" +
                    $"            () => _fb.{FlatBufferStructPropertyName}Length,\n" +
                    $"                i => new ParameterReference<{_genericType.Name}>(_parameterManager, _fb.{FlatBufferStructPropertyName}(i)));\n" +

--- a/Editor/Common/PropertyTypes/ParameterReferencePropertyType.cs
+++ b/Editor/Common/PropertyTypes/ParameterReferencePropertyType.cs
@@ -34,21 +34,15 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public {SanitizedPropertyTypeName()}<{_genericType.Name}> {PropertyName} => {FieldName};";
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {SanitizedPropertyTypeName()}<{_genericType.Name}> {OverrideFieldName};";
-
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             var referenceClassName = SanitizedPropertyTypeName();
             return
-                $"public {referenceClassName}<{_genericType.Name}> {PropertyName} => {OverrideFieldName} ?? new {referenceClassName}<{_genericType.Name}>(_parameterManager, _fb.{FlatBufferStructPropertyName});";
+                $"public {referenceClassName}<{_genericType.Name}> {PropertyName} => TryGetOverride<{SanitizedPropertyTypeName()}<{_genericType.Name}>>({propertyIndex}, out var val) ? val : new {referenceClassName}<{_genericType.Name}>(_parameterManager, _fb.{FlatBufferStructPropertyName});";
         }
 
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {FromStringCode(variableName)};";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{SanitizedPropertyTypeName()}<{_genericType.Name}>>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName)
         {

--- a/Editor/Common/PropertyTypes/ParameterStructReferenceListPropertyType.cs
+++ b/Editor/Common/PropertyTypes/ParameterStructReferenceListPropertyType.cs
@@ -61,16 +61,16 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
                    $"        {FieldName}[i].{nameof(IParameterScriptableObjectStruct.CollectLocalizationStrings)}({localizationKeysArgumentName}, {localizedScriptArgumentName});";
         }
 
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             return $"public IReadOnlyList<ParameterStructReference<{_genericType.Name}>> {PropertyName}\n" +
                    $"{{\n" +
                    $"    get\n" +
                    $"    {{\n" +
-                   $"        if ({OverrideFieldName} != null)\n" +
+                   $"        if (TryGetOverride<string[]>({propertyIndex}, out var val))\n" +
                    $"            return new ReadOnlyListContainer<ParameterStructReference<{_genericType.Name}>>(\n" +
-                   $"                () => {OverrideFieldName}.Length,\n" +
-                   $"                i => new ParameterStructReferenceRuntime<{_genericType.Name}>(_parameterManager, {OverrideFieldName}[i]));\n" +
+                   $"                () => val.Length,\n" +
+                   $"                i => new ParameterStructReferenceRuntime<{_genericType.Name}>(_parameterManager, val[i]));\n" +
                    $"        return new ReadOnlyListContainer<ParameterStructReference<{_genericType.Name}>>(\n" +
                    $"            () => _fb.{FlatBufferStructPropertyName}Length,\n" +
                    $"                i => new ParameterStructReferenceRuntime<{_genericType.Name}>(_parameterManager, _fb.{FlatBufferStructPropertyName}(i)));\n" +

--- a/Editor/Common/PropertyTypes/ParameterStructReferencePropertyType.cs
+++ b/Editor/Common/PropertyTypes/ParameterStructReferencePropertyType.cs
@@ -43,17 +43,15 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         // flat buffer guids are always deterministic and shouldn't change via ab testing
         public override string FlatBufferFieldDefinitionCode() => null;
 
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             var referenceClassName = SanitizedPropertyTypeName();
             return
                 $"public {referenceClassName}<{_genericType.Name}> {PropertyName} => new ParameterStructReferenceRuntime<{_genericType.Name}>(_parameterManager, _fb.{FlatBufferStructPropertyName});";
         }
 
-        public override string FlatBufferEditPropertyCode(string variableName) =>
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
             "error = $\"Cannot modify a ParameterStructReference with key-value {propertyName}:{value}. ParameterStructReference always point to a predefined guid based on key path.)\";";
-
-        public override string FlatBufferRemoveEditCode() => null;
 
         public override string FlatBufferBuilderPrepareCode(string tableName)
         {

--- a/Editor/Common/PropertyTypes/StandardListPropertyType.cs
+++ b/Editor/Common/PropertyTypes/StandardListPropertyType.cs
@@ -21,17 +21,14 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public IReadOnlyList<{_typeKeyword}> {PropertyName} => {FieldName};";
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {_typeKeyword}[] {OverrideFieldName};";
-
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             return $"public IReadOnlyList<{_typeKeyword}> {PropertyName}\n" +
                    $"{{\n" +
                    $"    get\n" +
                    $"    {{\n" +
-                   $"        if ({OverrideFieldName} != null)\n" +
-                   $"            return {OverrideFieldName};\n" +
+                   $"        if (TryGetOverride<{_typeKeyword}[]>({propertyIndex}, out var val))\n" +
+                   $"            return val;\n" +
                    $"        return new ReadOnlyListContainer<{_typeKeyword}>(\n" +
                    $"            () => _fb.{FlatBufferStructPropertyName}Length,\n" +
                    $"            i => _fb.{FlatBufferStructPropertyName}(i));\n" +
@@ -39,11 +36,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
                    $"}}";
         }
 
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {FromStringCode(variableName)};";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{_typeKeyword}[]>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName)
         {

--- a/Editor/Common/PropertyTypes/StandardPropertyType.cs
+++ b/Editor/Common/PropertyTypes/StandardPropertyType.cs
@@ -21,17 +21,11 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public {_typeKeyword} {PropertyName} => {FieldName};";
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {_typeKeyword}? {OverrideFieldName};";
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex) =>
+            $"public {_typeKeyword} {PropertyName} => TryGetOverride<{_typeKeyword}>({propertyIndex}, out var val) ? val : _fb.{FlatBufferStructPropertyName};";
 
-        public override string FlatBufferPropertyImplementationCode() =>
-            $"public {_typeKeyword} {PropertyName} => {OverrideFieldName} ?? _fb.{FlatBufferStructPropertyName};";
-
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {FromStringCode(variableName)};";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{_typeKeyword}>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName) => null;
 

--- a/Editor/Common/PropertyTypes/StringListPropertyType.cs
+++ b/Editor/Common/PropertyTypes/StringListPropertyType.cs
@@ -31,10 +31,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
             return null;
         }
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private string[] {OverrideFieldName};";
-
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             if (HasLocalizationKeyAttribute || HasLocalizedScriptAttribute)
             {
@@ -48,10 +45,10 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
                      $"{{\n" +
                      $"    get\n" +
                      $"    {{\n" +
-                     $"        if ({OverrideFieldName} != null)\n" +
+                     $"        if (TryGetOverride<string[]>({propertyIndex}, out var val))\n" +
                      $"            return new ReadOnlyListContainer<string>(\n" +
-                     $"                () => {OverrideFieldName}.Length,\n" +
-                     $"                i => {localizationCall}({OverrideFieldName}[i]));\n" +
+                     $"                () => val.Length,\n" +
+                     $"                i => {localizationCall}(val[i]));\n" +
                      $"        return new ReadOnlyListContainer<string>(\n" +
                      $"            () => _fb.{FlatBufferStructPropertyName}Length,\n" +
                      $"            i => {localizationCall}(_fb.{FlatBufferStructPropertyName}(i)));\n" +
@@ -63,8 +60,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
                    $"{{\n" +
                    $"    get\n" +
                    $"    {{\n" +
-                   $"        if ({OverrideFieldName} != null)\n" +
-                   $"            return {OverrideFieldName};\n" +
+                   $"        if (TryGetOverride<string[]>({propertyIndex}, out var val))\n" +
+                   $"            return val;\n" +
                    $"        return new ReadOnlyListContainer<string>(\n" +
                    $"            () => _fb.{FlatBufferStructPropertyName}Length,\n" +
                    $"            i => _fb.{FlatBufferStructPropertyName}(i));\n" +
@@ -72,11 +69,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
                    $"}}";
         }
 
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {FromStringCode(variableName)};";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<string[]>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName)
         {

--- a/Editor/Common/PropertyTypes/StringPropertyType.cs
+++ b/Editor/Common/PropertyTypes/StringPropertyType.cs
@@ -30,22 +30,19 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
             return null;
         }
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {_typeKeyword} {OverrideFieldName};";
-
-        public override string FlatBufferPropertyImplementationCode()
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex)
         {
             if (HasLocalizationKeyAttribute)
-                return $"public {_typeKeyword} {PropertyName} => {nameof(ParameterLocalizationHandler)}.{nameof(ParameterLocalizationHandler.GetLocalizationKeyTranslation)}({OverrideFieldName} ?? _fb.{FlatBufferStructPropertyName});";
+                return $"public {_typeKeyword} {PropertyName} => {nameof(ParameterLocalizationHandler)}.{nameof(ParameterLocalizationHandler.GetLocalizationKeyTranslation)}(TryGetOverride<{_typeKeyword}>({propertyIndex}, out var val) ? val : _fb.{FlatBufferStructPropertyName});";
 
             if (HasLocalizedScriptAttribute)
-                return $"public {_typeKeyword} {PropertyName} => {nameof(ParameterLocalizationHandler)}.{nameof(ParameterLocalizationHandler.GetLocalizableScriptTranslation)}({OverrideFieldName} ?? _fb.{FlatBufferStructPropertyName});";
+                return $"public {_typeKeyword} {PropertyName} => {nameof(ParameterLocalizationHandler)}.{nameof(ParameterLocalizationHandler.GetLocalizableScriptTranslation)}(TryGetOverride<{_typeKeyword}>({propertyIndex}, out var val) ? val : _fb.{FlatBufferStructPropertyName});";
 
-            return base.FlatBufferPropertyImplementationCode();
+            return base.FlatBufferPropertyImplementationCode(propertyIndex);
         }
 
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {variableName};";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{_typeKeyword}>({propertyIndex}, {variableName}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName) =>
             $"var sharedString{FlatBufferStructPropertyName} = _builder.CreateSharedString(data.{PropertyName});";

--- a/Editor/Common/PropertyTypes/Vector2PropertyType.cs
+++ b/Editor/Common/PropertyTypes/Vector2PropertyType.cs
@@ -24,17 +24,11 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public {VectorStructName} {PropertyName} => {FieldName};";
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {VectorStructName}? {OverrideFieldName};";
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex) =>
+            $"public {VectorStructName} {PropertyName} => TryGetOverride<{VectorStructName}>({propertyIndex}, out var val) ? val : new {VectorStructName}(_fb.{fbPropertyX}, _fb.{fbPropertyY});";
 
-        public override string FlatBufferPropertyImplementationCode() =>
-            $"public {VectorStructName} {PropertyName} => {OverrideFieldName} ?? new {VectorStructName}(_fb.{fbPropertyX}, _fb.{fbPropertyY});";
-
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {FromStringCode(variableName)};";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{VectorStructName}>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName) => null;
 

--- a/Editor/Common/PropertyTypes/Vector3PropertyType.cs
+++ b/Editor/Common/PropertyTypes/Vector3PropertyType.cs
@@ -21,17 +21,11 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string ScriptableObjectPropertyImplementationCode() =>
             $"public {VectorStructName} {PropertyName} => {FieldName};";
 
-        public override string FlatBufferFieldDefinitionCode() =>
-            $"private {VectorStructName}? {OverrideFieldName};";
+        public override string FlatBufferPropertyImplementationCode(int propertyIndex) =>
+            $"public {VectorStructName} {PropertyName} => TryGetOverride<{VectorStructName}>({propertyIndex}, out var val) ? val : new {VectorStructName}(_fb.{fbPropertyX}, _fb.{fbPropertyY}, _fb.{fbPropertyZ});";
 
-        public override string FlatBufferPropertyImplementationCode() =>
-            $"public {VectorStructName} {PropertyName} => {OverrideFieldName} ?? new {VectorStructName}(_fb.{fbPropertyX}, _fb.{fbPropertyY}, _fb.{fbPropertyZ});";
-
-        public override string FlatBufferEditPropertyCode(string variableName) =>
-            $"{OverrideFieldName} = {FromStringCode(variableName)};";
-
-        public override string FlatBufferRemoveEditCode() =>
-            $"{OverrideFieldName} = null;";
+        public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
+            $"return TrySetOverride<{VectorStructName}>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
 
         private string fbPropertyX => FlatBufferStructPropertyName + "X";
         private string fbPropertyY => FlatBufferStructPropertyName + "Y";

--- a/Editor/Common/Templates/FlatBufferClass.template
+++ b/Editor/Common/Templates/FlatBufferClass.template
@@ -16,12 +16,11 @@ namespace {{namespace}}
 #if {{disableSymbol}}
     internal class {{className}}
 #else
-    internal class {{className}} : {{interfaceName}}, IMutableParameter
+    internal class {{className}} : {{baseClassName}}, {{interfaceName}}
 #endif
     {
-        #region  private fields
+        #region private fields
 
-        private {{parameterManagerType}} _parameterManager;
         private {{flatBufferStructName}} _fb;
 {{~
 for propertyTypeDict in propertyTypeDicts
@@ -39,10 +38,9 @@ end
 
         #endregion
 
-        public {{className}}({{parameterManagerType}} parameterManager, {{flatBufferStructName}} fb)
+        public {{className}}({{parameterManagerType}} parameterManager, {{flatBufferStructName}} fb) : base(parameterManager)
         {
             _fb = fb;
-            _parameterManager = parameterManager;
         }
 
 {{~if isInfo~}}
@@ -62,12 +60,11 @@ end
 
         #region  mutation
 
-        public bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error)
+        public override bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error)
         {
             error = null;
             try
             {
-                // TODO optimize further if needed
                 switch (propertyName)
                 {
                     {{~for propertyTypeDict in propertyTypeDicts~}}
@@ -94,24 +91,7 @@ end
             return error == null;
         }
 
-        public void RemoveAllEdits()
-        {
-{{~
-    for propertyTypeDict in propertyTypeDicts
-        if propertyTypeDict.removeEditCode == null
-            continue
-        end
-        lines = propertyTypeDict.removeEditCode | regex.split `\n`
-        for line in lines
-~}}
-            {{ line }}
-{{~
-        end
-    end
-~}}
-        }
-
-        public IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager)
+        public override IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager)
         {
             // cast needed if interface implementations are disabled
             return (IMutableParameter)new {{className}}(parameterManager, _fb);

--- a/Runtime/Interface/BaseInfoFlatBuffer.cs
+++ b/Runtime/Interface/BaseInfoFlatBuffer.cs
@@ -1,0 +1,48 @@
+namespace PocketGems.Parameters.Interface
+{
+    public abstract class BaseInfoFlatBuffer : IMutableParameter
+    {
+        protected readonly IParameterManager _parameterManager;
+        protected ParameterOverrides _parameterOverrides;
+
+        protected BaseInfoFlatBuffer(IParameterManager parameterManager)
+        {
+            _parameterManager = parameterManager;
+        }
+
+        public abstract bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error);
+
+        protected bool TryGetOverride<T>(int index, out T parameterOverride)
+        {
+            if (_parameterOverrides == null)
+            {
+                parameterOverride = default;
+                return false;
+            }
+
+            if (!_parameterOverrides.TryGetOverride(index, out var obj))
+            {
+                parameterOverride = default;
+                return false;
+            }
+
+            parameterOverride = (T)obj;
+            return true;
+        }
+
+        protected bool TrySetOverride<T>(int index, T parameterOverride, int maxIndex, out string error)
+        {
+            if (_parameterOverrides == null)
+                _parameterOverrides = new();
+
+            return _parameterOverrides.SetEditedProperty(index, parameterOverride, maxIndex, out error);
+        }
+
+        public void RemoveAllEdits()
+        {
+            _parameterOverrides = null;
+        }
+
+        public abstract IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager);
+    }
+}

--- a/Runtime/Interface/BaseInfoFlatBuffer.cs.meta
+++ b/Runtime/Interface/BaseInfoFlatBuffer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9ebbcaabc1c843729e41b5494a64e048
+timeCreated: 1769111490

--- a/Runtime/Interface/ParameterOverrides.cs
+++ b/Runtime/Interface/ParameterOverrides.cs
@@ -1,0 +1,110 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PocketGems.Parameters.Interface
+{
+    /// <summary>
+    /// Internal container ab tests that IMutableParameter might have.
+    ///
+    /// Developer Memory Notes:
+    /// This container could be implemented with a string[] instead of the current two data structures.
+    /// This would come at different trade offs depending on usage.
+    ///
+    ///  Bit Array + Dict: bit array uses 1 bit per (index), dict uses 24 Bytes per entry + internal data structures overhead.
+    ///  string[]: array uses a block of memory 8 Bytes per pointer (index) size + object header.
+    ///
+    /// Some high level analysis:
+    /// - If overriding is sparse (e.g. just 1 field), string[] is more efficient if the # of fields is less than 30.
+    /// - If overriding is dense (e.g. all fields), string[] is always more efficient because you use all the references.
+    /// - Overall if 25% of the fields are overridden, string[] is more efficient, otherwise dict[] is more efficient.
+    ///
+    /// Our general use case assume that overriding should be sparse.  Most designers would override a whole column
+    /// of data which would mean sparse for each row of data. The only exception is if we add a whole rows of data,
+    /// the override would be dense.  This should only be a one off and wouldn't be done often.  If many rows are added
+    /// it should be done via a whole parameter byte file rather than through overrides.
+    /// </summary>
+    public class ParameterOverrides
+    {
+        /// <summary>
+        /// We use the overrides flag for performance and only access the dict if needed since dict
+        /// is slower due to hashing and looking up.
+        /// </summary>
+        private BitArray _overridesFlag;
+
+        /// <summary>
+        /// Internal dictionary of overridden fields.
+        /// </summary>
+        private Dictionary<int, object> _overridesDict;
+
+        public bool TryGetOverride(int index, out object value)
+        {
+            if (index < 0)
+            {
+                Debug.LogError("Attempting to fetch index outside of bounds.");
+                value = null;
+                return false;
+            }
+
+            if (_overridesFlag == null)
+            {
+                value = null;
+                return false;
+            }
+
+            if (index < 0 || index >= _overridesFlag.Count)
+            {
+                Debug.LogError("Attempting to fetch index outside of bounds.");
+                value = null;
+                return false;
+            }
+
+            if (!_overridesFlag[index])
+            {
+                value = null;
+                return false;
+            }
+
+            value = _overridesDict[index];
+            return true;
+        }
+
+        public bool SetEditedProperty(int index, object obj, int maxSize, out string error)
+        {
+            if (maxSize <= 0)
+            {
+                error = "Max size must be a positive number - package bug.";
+                return false;
+            }
+
+            if (maxSize <= index)
+            {
+                error = "Max size must be greater than index - package bug.";
+                return false;
+            }
+
+            if (_overridesFlag == null)
+            {
+                _overridesFlag = new(maxSize);
+                _overridesDict = new();
+            }
+
+            if (maxSize != _overridesFlag.Count)
+            {
+                error = "Max size changed - package bug.";
+                return false;
+            }
+
+            if (_overridesFlag[index])
+            {
+                error = "Overrides is already set.";
+                return false;
+            }
+
+            error = null;
+            _overridesFlag[index] = true;
+            _overridesDict[index] = obj;
+            return true;
+        }
+    }
+}

--- a/Runtime/Interface/ParameterOverrides.cs.meta
+++ b/Runtime/Interface/ParameterOverrides.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 101ba900b23e49229337d2e40fffc2aa
+timeCreated: 1769105904

--- a/Tests/Editor/Common/MockedInterfaces.cs
+++ b/Tests/Editor/Common/MockedInterfaces.cs
@@ -69,9 +69,8 @@ namespace PocketGems.Parameters.Editor
             mock.FlatBufferBuilderPrepareCode(default).ReturnsForAnyArgs("");
             mock.FlatBufferBuilderCode(default).ReturnsForAnyArgs("");
             mock.FlatBufferFieldDefinitionCode().ReturnsForAnyArgs("code");
-            mock.FlatBufferPropertyImplementationCode().ReturnsForAnyArgs("");
-            mock.FlatBufferEditPropertyCode("value").ReturnsForAnyArgs("");
-            mock.FlatBufferRemoveEditCode().ReturnsForAnyArgs("code");
+            mock.FlatBufferPropertyImplementationCode(default).ReturnsForAnyArgs("");
+            mock.FlatBufferEditPropertyCode(1, 10, "value").ReturnsForAnyArgs("");
             mock.ScriptableObjectFieldAttributesCode().ReturnsForAnyArgs(new List<string> { "attribute" });
             mock.ScriptableObjectFieldDefinitionCode().ReturnsForAnyArgs("field");
             mock.ScriptableObjectPropertyImplementationCode().ReturnsForAnyArgs("");

--- a/Tests/Editor/Common/PropertyTypes/PropertyTypesTest.cs
+++ b/Tests/Editor/Common/PropertyTypes/PropertyTypesTest.cs
@@ -138,7 +138,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
 
         private void AssertPropertyType(IPropertyType propertyType,
             bool expectNullPrepareSource = false,
-            bool expectImmutableFlatBufferData = false,
+            bool expectFlatBufferFieldDefinition = false,
             bool expectLocalization = false,
             bool isBaseInfoIdentifier = false)
         {
@@ -158,16 +158,12 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
             else
                 Assert.IsNull(localizationStrings);
 
-            if (expectImmutableFlatBufferData)
-                Assert.IsNull(propertyType.FlatBufferFieldDefinitionCode());
-            else
+            if (expectFlatBufferFieldDefinition)
                 Assert.IsNotEmpty(propertyType.FlatBufferFieldDefinitionCode());
-            Assert.IsNotEmpty(propertyType.FlatBufferPropertyImplementationCode());
-            Assert.IsNotEmpty(propertyType.FlatBufferEditPropertyCode("value"));
-            if (isBaseInfoIdentifier || expectImmutableFlatBufferData)
-                Assert.IsNull(propertyType.FlatBufferRemoveEditCode());
             else
-                Assert.IsNotEmpty(propertyType.FlatBufferRemoveEditCode());
+                Assert.IsNull(propertyType.FlatBufferFieldDefinitionCode());
+            Assert.IsNotEmpty(propertyType.FlatBufferPropertyImplementationCode(1));
+            Assert.IsNotEmpty(propertyType.FlatBufferEditPropertyCode(1, 10, "value"));
 
             if (expectNullPrepareSource)
                 Assert.IsNull(propertyType.FlatBufferBuilderPrepareCode(TableName));
@@ -198,7 +194,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public void ValidateIdentifier()
         {
             var identifierPropertyType = CreatePropertyType(nameof(IBaseInfo.Identifier), typeof(IBaseInfo));
-            AssertPropertyType(identifierPropertyType, isBaseInfoIdentifier: true);
+            AssertPropertyType(identifierPropertyType, isBaseInfoIdentifier: true, expectFlatBufferFieldDefinition: true);
 
             identifierPropertyType = CreatePropertyType(nameof(ITestStruct.Identifier), typeof(ITestStruct));
             AssertPropertyType(identifierPropertyType);
@@ -246,7 +242,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         [TestCase(nameof(ITestInfo.MyTestInfo))]
         [TestCase(nameof(ITestInfo.MyTestInfos))]
         [TestCase(nameof(ITestInfo.MyTestInfos))]
-        [TestCase(nameof(ITestInfo.MyStruct), false, true, true)]
+        [TestCase(nameof(ITestInfo.MyStruct), false, false, true)]
         [TestCase(nameof(ITestInfo.MyStructs), false, false, true)]
 #if ADDRESSABLE_PARAMS
         [TestCase(nameof(ITestInfo.MyAsset))]
@@ -260,13 +256,13 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
 #endif
         public void ValidateTypes(string propertyName,
             bool expectNullPrepareSource = false,
-            bool expectNullFlatBufferFieldDefinitionCode = false,
+            bool expectFlatBufferFieldDefinition = false,
             bool expectLocalization = false)
         {
             var propertyType = CreatePropertyType(propertyName);
             AssertPropertyType(propertyType,
                 expectNullPrepareSource: expectNullPrepareSource,
-                expectImmutableFlatBufferData: expectNullFlatBufferFieldDefinitionCode,
+                expectFlatBufferFieldDefinition: expectFlatBufferFieldDefinition,
                 expectLocalization: expectLocalization);
         }
 

--- a/Tests/Runtime/Interface/BaseInfoFlatBufferTest.cs
+++ b/Tests/Runtime/Interface/BaseInfoFlatBufferTest.cs
@@ -1,0 +1,75 @@
+using NUnit.Framework;
+
+namespace PocketGems.Parameters.Interface
+{
+    public class BaseInfoFlatBufferTest
+    {
+        private class BaseInfoFlatBufferSubclass : BaseInfoFlatBuffer
+        {
+            public BaseInfoFlatBufferSubclass(IParameterManager parameterManager) : base(parameterManager)
+            {
+            }
+
+            public override bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error)
+            {
+                error = null;
+                return true;
+            }
+
+            public bool TestTryGetOverride<T>(int index, out T parameterOverride) =>
+                TryGetOverride(index, out parameterOverride);
+
+            public bool TestTrySetOverride<T>(int index, T parameterOverride, int maxIndex, out string error) =>
+                TrySetOverride<T>(index, parameterOverride, maxIndex, out error);
+
+            public override IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager) => new BaseInfoFlatBufferSubclass(
+                parameterManager);
+        }
+
+        private BaseInfoFlatBufferSubclass _infoFlatBuffer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _infoFlatBuffer = new BaseInfoFlatBufferSubclass(null);
+        }
+
+        [Test]
+        public void CoverageMethodCalls()
+        {
+            _infoFlatBuffer.EditProperty(null, null, null, out _);
+            _ = _infoFlatBuffer.CreateLinkedMutableParameter(null);
+        }
+
+        [Test]
+        public void Overrides()
+        {
+            const int max = 5;
+            const int indexA = 4;
+            const int valueA = 5;
+
+            // set first
+            Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(indexA, out _), Is.False);
+            Assert.That(_infoFlatBuffer.TestTrySetOverride<int>(indexA, valueA, max, out _), Is.True);
+            Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(indexA, out var intValue), Is.True);
+            Assert.That(intValue, Is.EqualTo(valueA));
+
+            // try to set again
+            Assert.That(_infoFlatBuffer.TestTrySetOverride<int>(indexA, valueA, max, out var error), Is.False);
+            Assert.That(error, Is.EqualTo("Overrides is already set."));
+
+            // set 2nd
+            const int indexB = 2;
+            const string valueB = "my name";
+            Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(indexB, out _), Is.False);
+            Assert.That(_infoFlatBuffer.TestTrySetOverride<string>(indexB, valueB, max, out _), Is.True);
+            Assert.That(_infoFlatBuffer.TestTryGetOverride<string>(indexB, out var stringValue), Is.True);
+            Assert.That(stringValue, Is.EqualTo(valueB));
+
+            // clear
+            _infoFlatBuffer.RemoveAllEdits();
+            Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(indexA, out _), Is.False);
+            Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(indexB, out _), Is.False);
+        }
+    }
+}

--- a/Tests/Runtime/Interface/BaseInfoFlatBufferTest.cs.meta
+++ b/Tests/Runtime/Interface/BaseInfoFlatBufferTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0f2a400c7cca41e78e24774a23807e6b
+timeCreated: 1769126301

--- a/Tests/Runtime/Interface/ParameterOverridesTest.cs
+++ b/Tests/Runtime/Interface/ParameterOverridesTest.cs
@@ -1,0 +1,103 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PocketGems.Parameters.Interface
+{
+    public class ParameterOverridesTest
+    {
+        private ParameterOverrides _parameterOverrides;
+        private const int MaxSize = 10;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _parameterOverrides = new();
+        }
+
+        [Test]
+        public void TryGetOverride()
+        {
+            const int setIndexA = 2;
+            const string setObjectA = "MyString";
+            const int setIndexB = 3;
+            const long setObjectB = 1000;
+
+            // set
+            Assert.That(_parameterOverrides.SetEditedProperty(setIndexA, setObjectA, MaxSize, out _), Is.True);
+            Assert.That(_parameterOverrides.SetEditedProperty(setIndexB, setObjectB, MaxSize, out _), Is.True);
+
+            // get all override indexes
+            for (int i = 0; i < MaxSize; i++)
+            {
+                var result = _parameterOverrides.TryGetOverride(i, out object value);
+                if (i == setIndexA)
+                {
+                    Assert.That(result, Is.True);
+                    Assert.That(value, Is.EqualTo(setObjectA));
+                }
+                else if (i == setIndexB)
+                {
+                    Assert.That(result, Is.True);
+                    Assert.That(value, Is.EqualTo(setObjectB));
+                }
+                else
+                {
+                    Assert.That(result, Is.False);
+                }
+            }
+        }
+
+        [Test]
+        public void TryGetOverride_Empty()
+        {
+            Assert.That(_parameterOverrides.TryGetOverride(1000, out _), Is.False);
+
+            LogAssert.Expect(LogType.Error, "Attempting to fetch index outside of bounds.");
+            Assert.That(_parameterOverrides.TryGetOverride(-1000, out _), Is.False);
+        }
+
+        [Test]
+        public void TryGetOverride_Errors()
+        {
+            LogAssert.Expect(LogType.Error, "Attempting to fetch index outside of bounds.");
+            Assert.That(_parameterOverrides.TryGetOverride(-1000, out _), Is.False);
+
+            // set to set size
+            Assert.That(_parameterOverrides.SetEditedProperty(1, "string", MaxSize, out _), Is.True);
+
+            // max size checks
+            LogAssert.Expect(LogType.Error, "Attempting to fetch index outside of bounds.");
+            Assert.That(_parameterOverrides.TryGetOverride(MaxSize, out _), Is.False);
+            LogAssert.Expect(LogType.Error, "Attempting to fetch index outside of bounds.");
+            Assert.That(_parameterOverrides.TryGetOverride(MaxSize + 1, out _), Is.False);
+            Assert.That(_parameterOverrides.TryGetOverride(MaxSize - 1, out _), Is.False);
+        }
+
+        [Test]
+        public void SetEditedProperty()
+        {
+            Assert.That(_parameterOverrides.SetEditedProperty(1, "s", 2, out _), Is.True);
+            Assert.That(_parameterOverrides.TryGetOverride(1, out var value), Is.True);
+            Assert.That(value, Is.EqualTo("s"));
+        }
+
+        [Test]
+        public void SetEditedProperty_Errors()
+        {
+            Assert.That(_parameterOverrides.SetEditedProperty(1, "string", -1, out var error), Is.False);
+            Assert.That(error, Is.EqualTo("Max size must be a positive number - package bug."));
+
+            Assert.That(_parameterOverrides.SetEditedProperty(100, "string", 10, out error), Is.False);
+            Assert.That(error, Is.EqualTo("Max size must be greater than index - package bug."));
+
+            Assert.That(_parameterOverrides.SetEditedProperty(1, "string", 5, out error), Is.True);
+
+            Assert.That(_parameterOverrides.SetEditedProperty(1, "string", 6, out error), Is.False);
+            Assert.That(error, Is.EqualTo("Max size changed - package bug."));
+
+            Assert.That(_parameterOverrides.SetEditedProperty(1, "string 2", 5, out error), Is.False);
+            Assert.That(error, Is.EqualTo("Overrides is already set."));
+        }
+    }
+}

--- a/Tests/Runtime/Interface/ParameterOverridesTest.cs.meta
+++ b/Tests/Runtime/Interface/ParameterOverridesTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6cbe35f5dbfa49989312be41098c2d17
+timeCreated: 1769126259

--- a/Tests/Runtime/ParameterStructReferenceTest.cs
+++ b/Tests/Runtime/ParameterStructReferenceTest.cs
@@ -55,7 +55,7 @@ namespace PocketGems.Parameters
         {
             var reference = new ParameterStructReferenceRuntime<IBaseStruct>(_parameterManagerMock, null);
             Assert.That(reference.Struct, Is.Null);
-            Assert.That(reference.ToString(), Is.Not.Null);
+            Assert.That(reference.ToString(), Does.Contain("not assigned"));
         }
 
         [Test]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.0.0",
+  "version": "5.0.1",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.0.1] - 2026-03-25
### Changed
- Reduced the memory foot print of InfoFlatBuffer instances.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
