### PR TITLE
Fix noisy editor error when accessing localized parameter properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.2] - 2026-04-23
+### Fixed
+- Set localization delegates in `EditorParams.Init()` to prevent noisy errors when accessing localized parameter properties in editor scripts.
+
 ## [5.0.1] - 2026-03-25
 ### Changed
 - Reduced the memory foot print of InfoFlatBuffer instances.

--- a/Runtime/EditorParams.cs
+++ b/Runtime/EditorParams.cs
@@ -50,6 +50,9 @@ namespace PocketGems.Parameters
             IParameterDataLoader dataLoader = CreateParameterDataLoader();
 
             Init(parameterManager, hotLoader, dataLoader);
+
+            ParameterLocalizationHandler.GlobalTranslateLocalizationKeyDelegate ??= localizationKey => localizationKey;
+            ParameterLocalizationHandler.GlobalTranslateLocalizableScriptDelegate ??= localizableScript => localizableScript;
         }
 
         /// <summary>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.0.1",
+  "version": "5.0.2",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.0.2] - 2026-04-23
### Fixed
- Set localization delegates in `EditorParams.Init()` to prevent noisy errors when accessing localized parameter properties in editor scripts.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
