### PR TITLE
Fix FolderCleanupOperationTest dirtying the project environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.3] - 2026-05-04
+### Fixed
+- `FolderCleanupOperationTest` now preserves real project directories before running, preventing the test from permanently deleting them.
+
 ## [5.0.2] - 2026-04-23
 ### Fixed
 - Set localization delegates in `EditorParams.Init()` to prevent noisy errors when accessing localized parameter properties in editor scripts.

--- a/Tests/Editor/DataGeneration/Operations/FolderCleanupOperationTest.cs
+++ b/Tests/Editor/DataGeneration/Operations/FolderCleanupOperationTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using NSubstitute;
 using NUnit.Framework;
@@ -14,6 +15,9 @@ namespace PocketGems.Parameters.DataGeneration.Operations.Editor
         private string LegacyResourcesDirectory => Path.Combine(new[] { "Assets", "Parameters", "Resources" });
         private string MiscDirectory1 => Path.Combine(new[] { "Assets", "Parameters", "GeneratedAssets", "Blah1" });
         private string MiscDirectory2 => Path.Combine(new[] { "Assets", "Parameters", "GeneratedAssets", "Blah2" });
+        private string TempBackupPath => Path.Combine(new[] { "Assets", "Parameters", "_TestBackup" });
+
+        private List<(string original, string backup)> _preservedDirectories;
 
         [SetUp]
         public override void SetUp()
@@ -21,7 +25,21 @@ namespace PocketGems.Parameters.DataGeneration.Operations.Editor
             base.SetUp();
             _contextMock.GeneratedAssetDirectory.Returns(RootPath);
 
-            TearDown();
+            // Move any real project directories that the operation would delete into a temp
+            // backup so the test doesn't permanently destroy them.
+            _preservedDirectories = new List<(string, string)>();
+            PreserveDirectory(LegacyResourcesDirectory);
+            var generatedAssetsRoot = Path.Combine(new[] { "Assets", "Parameters", "GeneratedAssets" });
+            if (Directory.Exists(generatedAssetsRoot))
+            {
+                foreach (var dir in Directory.GetDirectories(generatedAssetsRoot, "*", SearchOption.TopDirectoryOnly))
+                {
+                    if (!RootPath.StartsWith(dir))
+                        PreserveDirectory(dir);
+                }
+            }
+
+            CleanupTestDirectories();
             Directory.CreateDirectory(LegacyResourcesDirectory);
             AssetDatabase.ImportAsset(LegacyResourcesDirectory);
             Directory.CreateDirectory(MiscDirectory1);
@@ -30,16 +48,43 @@ namespace PocketGems.Parameters.DataGeneration.Operations.Editor
             AssetDatabase.ImportAsset(MiscDirectory2);
         }
 
-        [TearDown]
-        public void TearDown()
+        private void PreserveDirectory(string path)
         {
-            // delete test folders
+            if (!Directory.Exists(path))
+                return;
+            if (!Directory.Exists(TempBackupPath))
+            {
+                Directory.CreateDirectory(TempBackupPath);
+                AssetDatabase.ImportAsset(TempBackupPath);
+            }
+            var backupPath = Path.Combine(TempBackupPath, Path.GetFileName(path));
+            AssetDatabase.MoveAsset(path, backupPath);
+            _preservedDirectories.Add((path, backupPath));
+        }
+
+        private void CleanupTestDirectories()
+        {
             if (Directory.Exists(LegacyResourcesDirectory))
                 AssetDatabase.DeleteAsset(LegacyResourcesDirectory);
             if (Directory.Exists(MiscDirectory1))
                 AssetDatabase.DeleteAsset(MiscDirectory1);
             if (Directory.Exists(MiscDirectory2))
                 AssetDatabase.DeleteAsset(MiscDirectory2);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            CleanupTestDirectories();
+
+            if (_preservedDirectories != null)
+            {
+                foreach (var (original, backup) in _preservedDirectories)
+                    AssetDatabase.MoveAsset(backup, original);
+                _preservedDirectories = null;
+            }
+            if (Directory.Exists(TempBackupPath))
+                AssetDatabase.DeleteAsset(TempBackupPath);
         }
 
         [Test]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.0.2",
+  "version": "5.0.3",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.0.3] - 2026-05-04
### Fixed
- `FolderCleanupOperationTest` now preserves real project directories before running, preventing the test from permanently deleting them.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
