### PR TITLE
5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.4] - 2026-05-06
+### Fixed
+- Issue with `AssertAssignedReferenceAttribute` incorrectly labeling an overridden ParameterReference as invalid.
+### Changed
+- Seperate editor CSV coversion from runtime override string conversion for similar behavior between device & editor.
+
 ## [5.0.3] - 2026-05-04
 ### Fixed
 - `FolderCleanupOperationTest` now preserves real project directories before running, preventing the test from permanently deleting them.

--- a/Editor/Common/EditorParameterConstants.cs
+++ b/Editor/Common/EditorParameterConstants.cs
@@ -18,7 +18,7 @@ namespace PocketGems.Parameters.Common.Editor
         /// Ideally it would be the most convenient to use the package version but that requires file I/O to
         /// the package.json which can be costly if we're doing it all of the time.
         /// </summary>
-        public const string InterfaceHashSalt = "aa9a175c-e1b9-4cab-bcb0-648ea1853c63";
+        public const string InterfaceHashSalt = "ca5735bb-61fd-4613-841b-f88229b443bd";
 
         public static string SanitizedDataPath()
         {

--- a/Editor/Common/PropertyTypes/ParameterReferenceListPropertyType.cs
+++ b/Editor/Common/PropertyTypes/ParameterReferenceListPropertyType.cs
@@ -60,7 +60,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string CSVBridgeColumnTypeText => $"{_genericType.Name}[]";
 
         public override string CSVBridgeReadFromCSVCode(string variableName) =>
-            $"data.{FieldName} = {nameof(CSVValueConverter)}.ParameterReferenceArray.FromString<{_genericType.Name}>(parameterManager, {variableName});";
+            $"data.{FieldName} = {nameof(CSVValueConverter)}.ParameterReferenceArray.FromCSVString<{_genericType.Name}>(parameterManager, {variableName});";
 
         public override string CSVBridgeUpdateCSVRowCode(string variableName) =>
             $"{variableName} = {nameof(CSVValueConverter)}.ParameterReferenceArray.ToString<{_genericType.Name}>(data.{FieldName});";

--- a/Editor/Common/PropertyTypes/ParameterReferencePropertyType.cs
+++ b/Editor/Common/PropertyTypes/ParameterReferencePropertyType.cs
@@ -42,7 +42,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         }
 
         public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
-            $"return TrySetOverride<{SanitizedPropertyTypeName()}<{_genericType.Name}>>({propertyIndex}, {FromStringCode(variableName)}, {maxPropertyIndex}, out error);";
+            $"return TrySetOverride<{SanitizedPropertyTypeName()}<{_genericType.Name}>>({propertyIndex}, {FromStringCode(variableName, "FromString")}, {maxPropertyIndex}, out error);";
 
         public override string FlatBufferBuilderPrepareCode(string tableName)
         {
@@ -57,7 +57,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string CSVBridgeColumnTypeText => _genericType.Name;
 
         public override string CSVBridgeReadFromCSVCode(string variableName) =>
-            $"data.{FieldName} = {FromStringCode(variableName)};";
+            $"data.{FieldName} = {FromStringCode(variableName, "FromCSVString")};";
 
         public override string CSVBridgeUpdateCSVRowCode(string variableName) =>
             $"{variableName} = {nameof(CSVValueConverter)}.{TypeString()}.ToString<{_genericType.Name}>(data.{FieldName});";
@@ -67,7 +67,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
             schemaBuilder.DefineField(tableName, FlatBufferStructPropertyName, FlatBufferFieldType.String);
         }
 
-        private string FromStringCode(string variableName) =>
-            $"{nameof(CSVValueConverter)}.{TypeString()}.FromString<{_genericType.Name}>(parameterManager, {variableName})";
+        private string FromStringCode(string variableName, string methodName) =>
+            $"{nameof(CSVValueConverter)}.{TypeString()}.{methodName}<{_genericType.Name}>(parameterManager, {variableName})";
     }
 }

--- a/Runtime/LocalCSV/CSVValueConverter.cs
+++ b/Runtime/LocalCSV/CSVValueConverter.cs
@@ -237,14 +237,13 @@ namespace PocketGems.Parameters.LocalCSV
                 }
                 return guid;
             }
-#endif
 
-            public static ParameterReference<T> FromString<T>(IParameterManager parameterManager, string value)
+            public static ParameterReference<T> FromCSVString<T>(IParameterManager parameterManager, string value)
                 where T : class, IBaseInfo
             {
                 if (string.IsNullOrWhiteSpace(value))
                     return new ParameterReference<T>(parameterManager);
-#if UNITY_EDITOR
+
                 if (ScriptableObjectLookupCache.Enabled)
                 {
                     var data = ScriptableObjectLookupCache.LookUp(value);
@@ -274,9 +273,15 @@ namespace PocketGems.Parameters.LocalCSV
                 }
 
                 throw new Exception($"Cannot find asset with name {value} of type {typeof(T)}");
-#else
-                return new ParameterReference<T>(parameterManager, value, true);
+            }
 #endif
+
+            public static ParameterReference<T> FromString<T>(IParameterManager parameterManager, string value)
+                where T : class, IBaseInfo
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    return new ParameterReference<T>(parameterManager);
+                return new ParameterReference<T>(parameterManager, value, true);
             }
         }
 
@@ -350,10 +355,27 @@ namespace PocketGems.Parameters.LocalCSV
                     strings[i] = CSVValueConverter.ParameterReference.ToString(value[i]);
                 return string.Join(ListDelimiter.ToString(), strings);
             }
+
+            public static ParameterReference<T>[] FromCSVString<T>(IParameterManager parameterManager, string value)
+                where T : class, IBaseInfo
+            {
+                // must return a non null value so we can detect overriding of properties by checking non null
+                if (string.IsNullOrWhiteSpace(value))
+                    return Array.Empty<ParameterReference<T>>();
+                var strings = value.Split(ListDelimiter);
+                var assetRefs = new ParameterReference<T>[strings.Length];
+                for (int i = 0; i < strings.Length; i++)
+                    assetRefs[i] = ParameterReference.FromCSVString<T>(parameterManager, strings[i]);
+                return assetRefs;
+            }
 #endif
 
+            /*
+             * Old method no longer used but marked obsolete until the next major release.
+             */
+            [Obsolete]
             public static ParameterReference<T>[] FromString<T>(IParameterManager parameterManager, string value)
-                    where T : class, IBaseInfo
+                where T : class, IBaseInfo
             {
                 // must return a non null value so we can detect overriding of properties by checking non null
                 if (string.IsNullOrWhiteSpace(value))

--- a/Runtime/Validation/Attributes/AssertAssignedReferenceAttribute.cs
+++ b/Runtime/Validation/Attributes/AssertAssignedReferenceAttribute.cs
@@ -50,8 +50,9 @@ namespace PocketGems.Parameters.Validation.Attributes
             }
 #endif
             // parameter reference
-            string assignedGuid = ((ParameterReference)element).AssignedGUID;
-            if (string.IsNullOrEmpty(assignedGuid))
+            var parameterReference = (ParameterReference)element;
+            if (string.IsNullOrWhiteSpace(parameterReference.AssignedGUID) &&
+                string.IsNullOrWhiteSpace(parameterReference.AssignedIdentifier))
                 return ErrorString;
             return null;
         }

--- a/Tests/Runtime/Validation/Attributes/AttributesTest.cs
+++ b/Tests/Runtime/Validation/Attributes/AttributesTest.cs
@@ -302,11 +302,14 @@ namespace PocketGems.Parameters.Validation.Attributes
 #endif
             AssertAttribute(attribute, nameof(ParameterReferenceArray), Array.Empty<ParameterReference<ISubInterfaceAInfo>>(), true);
 
+            // true - reference with identifier only (no GUID)
+            AssertAttribute(attribute, nameof(ParameterReference), new ParameterReference<ISubInterfaceAInfo>(_parameterManager, "identifier", true), true);
+
             // false references
             AssertAttribute(attribute, nameof(ParameterReference), null, false);
             AssertAttribute(attribute, nameof(ParameterReference), new ParameterReference<ISubInterfaceAInfo>(_parameterManager), false);
             AssertAttribute(attribute, nameof(ParameterReference), new ParameterReference<ISubInterfaceAInfo>(_parameterManager, ""), false);
-            AssertAttribute(attribute, nameof(ParameterReference), new ParameterReference<ISubInterfaceAInfo>(_parameterManager, "identifier", true), false);
+            AssertAttribute(attribute, nameof(ParameterReference), new ParameterReference<ISubInterfaceAInfo>(_parameterManager, "", true), false);
 #if ADDRESSABLE_PARAMS
             AssertAttribute(attribute, nameof(AssetReference), new AssetReference(), false);
             AssertAttribute(attribute, nameof(AssetReference), new AssetReference(""), false);
@@ -329,6 +332,12 @@ namespace PocketGems.Parameters.Validation.Attributes
             ParameterReferenceArray = new[] {
                 new ParameterReference<ISubInterfaceAInfo>(_parameterManager, testGuid),
                 new ParameterReference<ISubInterfaceAInfo>(_parameterManager, "identifier", true) };
+            AssertAttribute(attribute, nameof(ParameterReferenceArray), ParameterReferenceArray, true);
+
+            // false - list with empty identifier reference
+            ParameterReferenceArray = new[] {
+                new ParameterReference<ISubInterfaceAInfo>(_parameterManager, testGuid),
+                new ParameterReference<ISubInterfaceAInfo>(_parameterManager, "", true) };
             AssertAttribute(attribute, nameof(ParameterReferenceArray), ParameterReferenceArray, false);
 
 #if ADDRESSABLE_PARAMS

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.0.3",
+  "version": "5.0.4",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.0.4] - 2026-05-06
### Fixed
- Issue with `AssertAssignedReferenceAttribute` incorrectly labeling an overridden ParameterReference as invalid.
### Changed
- Seperate editor CSV coversion from runtime override string conversion for similar behavior between device & editor.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
