### PR TITLE
Fix non-English locale floating point parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.5] - 2026-05-19
+### Fixed
+- `float.Parse` calls in `CSVValueConverter` and `Vector3Parser` now use `CultureInfo.InvariantCulture`, fixing "Input string was not in a correct format" errors when applying parameter overrides on machines with a non-English locale (e.g. German, French) where `.` is not the decimal separator.
+
 ## [5.0.4] - 2026-05-06
 ### Fixed
 - Issue with `AssertAssignedReferenceAttribute` incorrectly labeling an overridden ParameterReference as invalid.

--- a/Runtime/LocalCSV/CSVValueConverter.cs
+++ b/Runtime/LocalCSV/CSVValueConverter.cs
@@ -49,7 +49,8 @@ namespace PocketGems.Parameters.LocalCSV
 
         public static class Vector2
         {
-            public static string ToString(UnityEngine.Vector2 value) => $"{value.x}{ValueDelimiter}{value.y}";
+            public static string ToString(UnityEngine.Vector2 value) =>
+                string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", value.x, ValueDelimiter, value.y);
 
             public static UnityEngine.Vector2 FromString(string value)
             {
@@ -57,8 +58,8 @@ namespace PocketGems.Parameters.LocalCSV
                     return new UnityEngine.Vector2();
                 var splitValues = value.Split(ValueDelimiter);
                 return new UnityEngine.Vector2(
-                    float.Parse(splitValues[0]),
-                    float.Parse(splitValues[1]));
+                    float.Parse(splitValues[0], CultureInfo.InvariantCulture),
+                    float.Parse(splitValues[1], CultureInfo.InvariantCulture));
             }
         }
 
@@ -80,7 +81,7 @@ namespace PocketGems.Parameters.LocalCSV
         public static class Vector3
         {
             public static string ToString(UnityEngine.Vector3 value) =>
-                $"{value.x}{ValueDelimiter}{value.y}{ValueDelimiter}{value.z}";
+                string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}{3}{4}", value.x, ValueDelimiter, value.y, ValueDelimiter, value.z);
 
             public static UnityEngine.Vector3 FromString(string value)
             {
@@ -88,9 +89,9 @@ namespace PocketGems.Parameters.LocalCSV
                     return new UnityEngine.Vector3();
                 var splitValues = value.Split(ValueDelimiter);
                 return new UnityEngine.Vector3(
-                    float.Parse(splitValues[0]),
-                    float.Parse(splitValues[1]),
-                    float.Parse(splitValues[2]));
+                    float.Parse(splitValues[0], CultureInfo.InvariantCulture),
+                    float.Parse(splitValues[1], CultureInfo.InvariantCulture),
+                    float.Parse(splitValues[2], CultureInfo.InvariantCulture));
             }
         }
 
@@ -183,7 +184,8 @@ namespace PocketGems.Parameters.LocalCSV
 
         public static class Numeric<T>
         {
-            public static string ToString(T value) => value.ToString();
+            public static string ToString(T value) =>
+                (value as IFormattable)?.ToString(null, CultureInfo.InvariantCulture) ?? value.ToString();
 
             public static T FromString(string value)
             {
@@ -206,7 +208,7 @@ namespace PocketGems.Parameters.LocalCSV
                 else if (typeof(T) == typeof(long))
                     o = long.Parse(value);
                 else if (typeof(T) == typeof(float))
-                    o = float.Parse(value);
+                    o = float.Parse(value, CultureInfo.InvariantCulture);
                 else
                     throw new Exception($"Unsupported type {typeof(T)}");
                 return (T)o;

--- a/Runtime/Parser/Vector3Parser.cs
+++ b/Runtime/Parser/Vector3Parser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using UnityEngine;
 
 namespace PocketGems.Parameters.Parser
@@ -18,7 +19,7 @@ namespace PocketGems.Parameters.Parser
             var values = str.Split(':');
             if (values.Length != 3)
                 throw new FormatException("string must have 3 elements delimited with :");
-            return new Vector3(float.Parse(values[0]), float.Parse(values[1]), float.Parse(values[2]));
+            return new Vector3(float.Parse(values[0], CultureInfo.InvariantCulture), float.Parse(values[1], CultureInfo.InvariantCulture), float.Parse(values[2], CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Tests/Runtime/LocalCSV/CSVValueConverterTest.CultureInvariant.cs
+++ b/Tests/Runtime/LocalCSV/CSVValueConverterTest.CultureInvariant.cs
@@ -1,0 +1,27 @@
+using System.Globalization;
+using System.Threading;
+using NUnit.Framework;
+
+namespace PocketGems.Parameters.LocalCSV
+{
+    public partial class CSVValueConverterTest
+    {
+        public class CultureInvariant : CSVValueConverterTest
+        {
+            private CultureInfo _originalCulture;
+
+            [SetUp]
+            public void SetUp()
+            {
+                _originalCulture = Thread.CurrentThread.CurrentCulture;
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                Thread.CurrentThread.CurrentCulture = _originalCulture;
+            }
+        }
+    }
+}

--- a/Tests/Runtime/LocalCSV/CSVValueConverterTest.CultureInvariant.cs.meta
+++ b/Tests/Runtime/LocalCSV/CSVValueConverterTest.CultureInvariant.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd603c933bda0485ebe490373a53c8c5

--- a/Tests/Runtime/Parser/Vector3ParserTest.CultureInvariant.cs
+++ b/Tests/Runtime/Parser/Vector3ParserTest.CultureInvariant.cs
@@ -1,0 +1,27 @@
+using System.Globalization;
+using System.Threading;
+using NUnit.Framework;
+
+namespace PocketGems.Parameters.Parser
+{
+    public partial class Vector3ParserTest
+    {
+        public class CultureInvariant : Vector3ParserTest
+        {
+            private CultureInfo _originalCulture;
+
+            [SetUp]
+            public void SetUp()
+            {
+                _originalCulture = Thread.CurrentThread.CurrentCulture;
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                Thread.CurrentThread.CurrentCulture = _originalCulture;
+            }
+        }
+    }
+}

--- a/Tests/Runtime/Parser/Vector3ParserTest.CultureInvariant.cs.meta
+++ b/Tests/Runtime/Parser/Vector3ParserTest.CultureInvariant.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c8636bd6a4a64489dab4ecff6467dbc0

--- a/Tests/Runtime/Parser/Vector3ParserTest.cs
+++ b/Tests/Runtime/Parser/Vector3ParserTest.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 
 namespace PocketGems.Parameters.Parser
 {
-    public class Vector3ParserTest
+    public partial class Vector3ParserTest
     {
         [Test]
         public void ParseVector3Int_Valid()

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.0.4",
+  "version": "5.0.5",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.0.5] - 2026-05-19
### Fixed
- `float.Parse` calls in `CSVValueConverter` and `Vector3Parser` now use `CultureInfo.InvariantCulture`, fixing "Input string was not in a correct format" errors when applying parameter overrides on machines with a non-English locale (e.g. German, French) where `.` is not the decimal separator.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
