### PR TITLE
Failed calls to the `IMutableParameterManager.ApplyOverrides()` will now revert any partial overrides upon failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.6] - 2026-05-21
+### Fixed
+- Failed calls to the `IMutableParameterManager.ApplyOverrides()` will now revert any partial overridesn upon failure.
+
 ## [5.0.5] - 2026-05-19
 ### Fixed
 - `float.Parse` calls in `CSVValueConverter` and `Vector3Parser` now use `CultureInfo.InvariantCulture`, fixing "Input string was not in a correct format" errors when applying parameter overrides on machines with a non-English locale (e.g. German, French) where `.` is not the decimal separator.

--- a/Editor/CodeGeneration/Util/CodeGenerator.cs
+++ b/Editor/CodeGeneration/Util/CodeGenerator.cs
@@ -290,6 +290,7 @@ namespace PocketGems.Parameters.CodeGeneration.Util.Editor
 
                 // edit property
                 propertyTypeDict["editPropertyCode"] = propertyType.FlatBufferEditPropertyCode(i, propertyTypes.Count, "value");
+                propertyTypeDict["revertEditPropertyCode"] = propertyType.FlatBufferRevertEditPropertyCode(i);
             }
 
             var args = new Dictionary<string, object>

--- a/Editor/Common/EditorParameterConstants.cs
+++ b/Editor/Common/EditorParameterConstants.cs
@@ -18,7 +18,7 @@ namespace PocketGems.Parameters.Common.Editor
         /// Ideally it would be the most convenient to use the package version but that requires file I/O to
         /// the package.json which can be costly if we're doing it all of the time.
         /// </summary>
-        public const string InterfaceHashSalt = "ca5735bb-61fd-4613-841b-f88229b443bd";
+        public const string InterfaceHashSalt = "5a84c143-0bf4-4a7c-adbe-36d92e2c6635";
 
         public static string SanitizedDataPath()
         {

--- a/Editor/Common/PropertyTypes/BasePropertyType.cs
+++ b/Editor/Common/PropertyTypes/BasePropertyType.cs
@@ -87,6 +87,8 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public virtual string FlatBufferFieldDefinitionCode() => null;
         public abstract string FlatBufferPropertyImplementationCode(int propertyIndex);
         public abstract string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName);
+        public virtual string FlatBufferRevertEditPropertyCode(int propertyIndex) =>
+            $"return TryRemoveOverride({propertyIndex}, out error);";
 
         public abstract string FlatBufferBuilderPrepareCode(string tableName);
         public abstract string FlatBufferBuilderCode(string tableName);

--- a/Editor/Common/PropertyTypes/IPropertyType.cs
+++ b/Editor/Common/PropertyTypes/IPropertyType.cs
@@ -23,6 +23,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         string FlatBufferFieldDefinitionCode();
         string FlatBufferPropertyImplementationCode(int propertyIndex);
         string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName);
+        string FlatBufferRevertEditPropertyCode(int propertyIndex);
 
         // FlatBufferBuilder code generation
         string FlatBufferBuilderPrepareCode(string tableName);

--- a/Editor/Common/PropertyTypes/IdentifierPropertyType.cs
+++ b/Editor/Common/PropertyTypes/IdentifierPropertyType.cs
@@ -28,6 +28,9 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
         public override string FlatBufferEditPropertyCode(int propertyIndex, int maxPropertyIndex, string variableName) =>
             $"throw new Exception(\"Cannot edit {PropertyName}.\");";
 
+        public override string FlatBufferRevertEditPropertyCode(int propertyIndex) =>
+            $"throw new Exception(\"Cannot revert edit {PropertyName}.\");";
+
         public override string CSVBridgeReadFromCSVCode(string variableName)
         {
             // must rename the scriptable object to rename identifier

--- a/Editor/Common/Templates/FlatBufferClass.template
+++ b/Editor/Common/Templates/FlatBufferClass.template
@@ -91,6 +91,38 @@ end
             return error == null;
         }
 
+        public override bool RevertEditedProperty(string propertyName, out string error)
+        {
+            error = null;
+            try
+            {
+                switch (propertyName)
+                {
+                    {{~for propertyTypeDict in propertyTypeDicts~}}
+                    case "{{propertyTypeDict.propertyName}}":
+                        {
+                        {{~ lines = propertyTypeDict.revertEditPropertyCode | regex.split `\n` ~}}
+                        {{~ for line in lines ~}}
+                            {{ line }}
+                        {{~ end ~}}
+                        }
+#pragma warning disable CS0162 // Unreachable code detected
+                        break;
+#pragma warning restore CS0162 // Unreachable code detected
+                    {{~end~}}
+                    default:
+                        error = "property doesn't exist";
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                error = e.Message;
+            }
+
+            return error == null;
+        }
+
         public override IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager)
         {
             // cast needed if interface implementations are disabled

--- a/Runtime/Interface/BaseInfoFlatBuffer.cs
+++ b/Runtime/Interface/BaseInfoFlatBuffer.cs
@@ -38,6 +38,20 @@ namespace PocketGems.Parameters.Interface
             return _parameterOverrides.SetEditedProperty(index, parameterOverride, maxIndex, out error);
         }
 
+        protected bool TryRemoveOverride<T>(int index, out string error)
+        {
+            if (_parameterOverrides == null)
+            {
+                error = "No overrides to remove.";
+                return false;
+            }
+
+            var success = _parameterOverrides.RemoveOverride(index, out error);
+            if (success && _parameterOverrides.OverrideCount == 0)
+                _parameterOverrides = null;
+            return success;
+        }
+
         public void RemoveAllEdits()
         {
             _parameterOverrides = null;

--- a/Runtime/Interface/BaseInfoFlatBuffer.cs
+++ b/Runtime/Interface/BaseInfoFlatBuffer.cs
@@ -12,6 +12,8 @@ namespace PocketGems.Parameters.Interface
 
         public abstract bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error);
 
+        public abstract bool RevertEditedProperty(string propertyName, out string error);
+
         protected bool TryGetOverride<T>(int index, out T parameterOverride)
         {
             if (_parameterOverrides == null)
@@ -38,7 +40,7 @@ namespace PocketGems.Parameters.Interface
             return _parameterOverrides.SetEditedProperty(index, parameterOverride, maxIndex, out error);
         }
 
-        protected bool TryRemoveOverride<T>(int index, out string error)
+        protected bool TryRemoveOverride(int index, out string error)
         {
             if (_parameterOverrides == null)
             {

--- a/Runtime/Interface/IMutableParameter.cs
+++ b/Runtime/Interface/IMutableParameter.cs
@@ -13,6 +13,14 @@ namespace PocketGems.Parameters.Interface
         bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error);
 
         /// <summary>
+        /// Reverts a single property edit that was applied with the EditProperty call.
+        /// </summary>
+        /// <param name="propertyName">the property name to revert</param>
+        /// <param name="error">any errors if the return value is false</param>
+        /// <returns>true if successful</returns>
+        bool RevertEditedProperty(string propertyName, out string error);
+
+        /// <summary>
         /// Remove all edits that were applied with the EditProperty call.
         /// </summary>
         void RemoveAllEdits();

--- a/Runtime/Interface/ParameterOverrides.cs
+++ b/Runtime/Interface/ParameterOverrides.cs
@@ -69,6 +69,34 @@ namespace PocketGems.Parameters.Interface
             return true;
         }
 
+        public int OverrideCount => _overridesDict?.Count ?? 0;
+
+        public bool RemoveOverride(int index, out string error)
+        {
+            if (_overridesFlag == null)
+            {
+                error = "No overrides to remove.";
+                return false;
+            }
+
+            if (index < 0 || index >= _overridesFlag.Count)
+            {
+                error = "Attempting to fetch index outside of bounds.";
+                return false;
+            }
+
+            if (!_overridesFlag[index])
+            {
+                error = "No overrides to remove.";
+                return false;
+            }
+
+            error = null;
+            _overridesFlag[index] = false;
+            _overridesDict.Remove(index);
+            return true;
+        }
+
         public bool SetEditedProperty(int index, object obj, int maxSize, out string error)
         {
             if (maxSize <= 0)

--- a/Runtime/LinkedParameterManager.cs
+++ b/Runtime/LinkedParameterManager.cs
@@ -106,7 +106,7 @@ namespace PocketGems.Parameters
         {
             // get the original mutable parameter that it would've applied to for mapping
             var mutableParameter = base.Get(interfaceType, identifierOrGuid) ??
-                                   base.GetWithGUID(interfaceType, identifierOrGuid);
+                               base.GetWithGUID(interfaceType, identifierOrGuid);
             if (mutableParameter == null)
             {
                 error = $"Cannot find parameter for csv [{csvName}] and identifier/guid [{identifierOrGuid}].";
@@ -118,6 +118,14 @@ namespace PocketGems.Parameters
             {
                 overridesToApply = new();
                 _overridesToApplyByParameter[mutableParameter] = overridesToApply;
+            }
+            foreach (var (existingProperty, _) in overridesToApply)
+            {
+                if (existingProperty == propertyName)
+                {
+                    error = $"({interfaceType})[{identifierOrGuid}] has more than one value for [{propertyName}] assigned ";
+                    return false;
+                }
             }
             overridesToApply.Add((propertyName, value));
 
@@ -132,6 +140,43 @@ namespace PocketGems.Parameters
                         {
                             error =
                                 $"Error editing ({interfaceType})[{identifierOrGuid}] property [{propertyName}] with value [{value}]: {error}";
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            error = null;
+            return true;
+        }
+
+        protected override bool RemoveOverride(string csvName, string interfaceType, string identifierOrGuid, string propertyName, out string error)
+        {
+            // get the original mutable parameter that it would've applied to for mapping
+            var mutableParameter = base.Get(interfaceType, identifierOrGuid) ??
+                                   base.GetWithGUID(interfaceType, identifierOrGuid);
+            if (mutableParameter == null)
+            {
+                error = $"Cannot find parameter for csv [{csvName}] and identifier/guid [{identifierOrGuid}].";
+                return false;
+            }
+
+            if (_overridesToApplyByParameter.TryGetValue(mutableParameter, out var overridesToApply))
+            {
+                overridesToApply.RemoveAll(o => o.Item1 == propertyName);
+                if (overridesToApply.Count == 0)
+                    _overridesToApplyByParameter.Remove(mutableParameter);
+            }
+
+            lock (_linkedMutableParameterCache)
+            {
+                if (_linkedMutableParameterCache.TryGetValue(mutableParameter, out WeakReference weakReference))
+                {
+                    if (weakReference.Target is IMutableParameter linkedParameter)
+                    {
+                        if (!linkedParameter.RevertEditedProperty(propertyName, out error))
+                        {
+                            error = $"Error reverting edit ({interfaceType})[{identifierOrGuid}] property [{propertyName}]: {error}";
                             return false;
                         }
                     }

--- a/Runtime/ParameterManager.cs
+++ b/Runtime/ParameterManager.cs
@@ -92,6 +92,7 @@ namespace PocketGems.Parameters
 
             if (edits != null)
             {
+                List<(string csvName, string identifierOrGuid, string propertyName, string interfaceType)> successfulOverrides = new();
                 foreach (var dataOverride in edits)
                 {
                     var array = (JArray)dataOverride;
@@ -107,9 +108,21 @@ namespace PocketGems.Parameters
                     var value = (string)array[3];
                     var interfaceType = LocalCSV.CSVUtil.CSVToInterfaceFileName(csvName);
 
-                    IMutableParameter mutableParameter;
+                    // apply all overrides even if an error occurs so we surface all errors for developers rather than one by one
                     if (!ApplyOverride(csvName, interfaceType, identifierOrGuid, propertyName, value, out string error))
                         Error(error);
+                    else
+                        successfulOverrides.Add((csvName, identifierOrGuid, propertyName, interfaceType));
+                }
+
+                if (!success)
+                {
+                    // revert changes if any of the overrides failed
+                    foreach (var (csvName, identifierOrGuid, propertyName, interfaceType) in successfulOverrides)
+                    {
+                        if (!RemoveOverride(csvName, interfaceType, identifierOrGuid, propertyName, out string error))
+                            Error(error);
+                    }
                 }
             }
 
@@ -336,6 +349,24 @@ namespace PocketGems.Parameters
                 return false;
             }
 
+            return true;
+        }
+
+        protected virtual bool RemoveOverride(string csvName, string interfaceType, string identifierOrGuid, string propertyName, out string error)
+        {
+            var mutableParameter = Get(interfaceType, identifierOrGuid) ??
+                                   GetWithGUID(interfaceType, identifierOrGuid);
+            if (mutableParameter == null)
+            {
+                error = $"Cannot find parameter for csv [{csvName}] and identifier/guid [{identifierOrGuid}].";
+                return false;
+            }
+
+            if (!mutableParameter.RevertEditedProperty(propertyName, out error))
+            {
+                error = $"Error reverting edit ({interfaceType})[{identifierOrGuid}] property [{propertyName}]: {error}";
+                return false;
+            }
             return true;
         }
 

--- a/Tests/Editor/Common/PropertyTypes/PropertyTypesTest.cs
+++ b/Tests/Editor/Common/PropertyTypes/PropertyTypesTest.cs
@@ -164,6 +164,7 @@ namespace PocketGems.Parameters.Common.PropertyTypes.Editor
                 Assert.IsNull(propertyType.FlatBufferFieldDefinitionCode());
             Assert.IsNotEmpty(propertyType.FlatBufferPropertyImplementationCode(1));
             Assert.IsNotEmpty(propertyType.FlatBufferEditPropertyCode(1, 10, "value"));
+            Assert.IsNotEmpty(propertyType.FlatBufferRevertEditPropertyCode(1));
 
             if (expectNullPrepareSource)
                 Assert.IsNull(propertyType.FlatBufferBuilderPrepareCode(TableName));

--- a/Tests/Runtime/Interface/BaseInfoFlatBufferTest.cs
+++ b/Tests/Runtime/Interface/BaseInfoFlatBufferTest.cs
@@ -22,6 +22,9 @@ namespace PocketGems.Parameters.Interface
             public bool TestTrySetOverride<T>(int index, T parameterOverride, int maxIndex, out string error) =>
                 TrySetOverride<T>(index, parameterOverride, maxIndex, out error);
 
+            public bool TestTryRemoveOverride<T>(int index, out string error) =>
+                TryRemoveOverride<T>(index, out error);
+
             public override IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager) => new BaseInfoFlatBufferSubclass(
                 parameterManager);
         }
@@ -70,6 +73,31 @@ namespace PocketGems.Parameters.Interface
             _infoFlatBuffer.RemoveAllEdits();
             Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(indexA, out _), Is.False);
             Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(indexB, out _), Is.False);
+        }
+
+        [Test]
+        public void RemoveOverride()
+        {
+            const int max = 5;
+            const int index = 2;
+
+            // remove with no overrides initialized
+            Assert.That(_infoFlatBuffer.TestTryRemoveOverride<int>(index, out var error), Is.False);
+            Assert.That(error, Is.EqualTo("No overrides to remove."));
+
+            // set then remove
+            Assert.That(_infoFlatBuffer.TestTrySetOverride<int>(index, 99, max, out _), Is.True);
+            Assert.That(_infoFlatBuffer.TestTryRemoveOverride<int>(index, out error), Is.True);
+            Assert.That(error, Is.Null);
+            Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(index, out _), Is.False);
+
+            // removing last override nulls out _parameterOverrides — re-set should succeed (not hit "max size changed")
+            Assert.That(_infoFlatBuffer.TestTrySetOverride<int>(index, 100, max, out error), Is.True);
+
+            // double remove
+            Assert.That(_infoFlatBuffer.TestTryRemoveOverride<int>(index, out _), Is.True);
+            Assert.That(_infoFlatBuffer.TestTryRemoveOverride<int>(index, out error), Is.False);
+            Assert.That(error, Is.EqualTo("No overrides to remove."));
         }
     }
 }

--- a/Tests/Runtime/Interface/BaseInfoFlatBufferTest.cs
+++ b/Tests/Runtime/Interface/BaseInfoFlatBufferTest.cs
@@ -16,14 +16,20 @@ namespace PocketGems.Parameters.Interface
                 return true;
             }
 
+            public override bool RevertEditedProperty(string propertyName, out string error)
+            {
+                error = null;
+                return true;
+            }
+
             public bool TestTryGetOverride<T>(int index, out T parameterOverride) =>
                 TryGetOverride(index, out parameterOverride);
 
             public bool TestTrySetOverride<T>(int index, T parameterOverride, int maxIndex, out string error) =>
-                TrySetOverride<T>(index, parameterOverride, maxIndex, out error);
+                TrySetOverride(index, parameterOverride, maxIndex, out error);
 
-            public bool TestTryRemoveOverride<T>(int index, out string error) =>
-                TryRemoveOverride<T>(index, out error);
+            public bool TestTryRemoveOverride(int index, out string error) =>
+                TryRemoveOverride(index, out error);
 
             public override IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager) => new BaseInfoFlatBufferSubclass(
                 parameterManager);
@@ -82,12 +88,12 @@ namespace PocketGems.Parameters.Interface
             const int index = 2;
 
             // remove with no overrides initialized
-            Assert.That(_infoFlatBuffer.TestTryRemoveOverride<int>(index, out var error), Is.False);
+            Assert.That(_infoFlatBuffer.TestTryRemoveOverride(index, out var error), Is.False);
             Assert.That(error, Is.EqualTo("No overrides to remove."));
 
             // set then remove
             Assert.That(_infoFlatBuffer.TestTrySetOverride<int>(index, 99, max, out _), Is.True);
-            Assert.That(_infoFlatBuffer.TestTryRemoveOverride<int>(index, out error), Is.True);
+            Assert.That(_infoFlatBuffer.TestTryRemoveOverride(index, out error), Is.True);
             Assert.That(error, Is.Null);
             Assert.That(_infoFlatBuffer.TestTryGetOverride<int>(index, out _), Is.False);
 
@@ -95,8 +101,8 @@ namespace PocketGems.Parameters.Interface
             Assert.That(_infoFlatBuffer.TestTrySetOverride<int>(index, 100, max, out error), Is.True);
 
             // double remove
-            Assert.That(_infoFlatBuffer.TestTryRemoveOverride<int>(index, out _), Is.True);
-            Assert.That(_infoFlatBuffer.TestTryRemoveOverride<int>(index, out error), Is.False);
+            Assert.That(_infoFlatBuffer.TestTryRemoveOverride(index, out _), Is.True);
+            Assert.That(_infoFlatBuffer.TestTryRemoveOverride(index, out error), Is.False);
             Assert.That(error, Is.EqualTo("No overrides to remove."));
         }
     }

--- a/Tests/Runtime/Interface/ParameterOverridesTest.cs
+++ b/Tests/Runtime/Interface/ParameterOverridesTest.cs
@@ -83,6 +83,61 @@ namespace PocketGems.Parameters.Interface
         }
 
         [Test]
+        public void OverrideCount()
+        {
+            Assert.That(_parameterOverrides.OverrideCount, Is.EqualTo(0));
+
+            _parameterOverrides.SetEditedProperty(0, "a", MaxSize, out _);
+            Assert.That(_parameterOverrides.OverrideCount, Is.EqualTo(1));
+
+            _parameterOverrides.SetEditedProperty(1, "b", MaxSize, out _);
+            Assert.That(_parameterOverrides.OverrideCount, Is.EqualTo(2));
+
+            _parameterOverrides.RemoveOverride(0, out _);
+            Assert.That(_parameterOverrides.OverrideCount, Is.EqualTo(1));
+
+            _parameterOverrides.RemoveOverride(1, out _);
+            Assert.That(_parameterOverrides.OverrideCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void RemoveOverride()
+        {
+            _parameterOverrides.SetEditedProperty(2, "val", MaxSize, out _);
+            Assert.That(_parameterOverrides.TryGetOverride(2, out _), Is.True);
+
+            Assert.That(_parameterOverrides.RemoveOverride(2, out var error), Is.True);
+            Assert.That(error, Is.Null);
+            Assert.That(_parameterOverrides.TryGetOverride(2, out _), Is.False);
+        }
+
+        [Test]
+        public void RemoveOverride_Errors()
+        {
+            // no overrides initialized
+            Assert.That(_parameterOverrides.RemoveOverride(0, out var error), Is.False);
+            Assert.That(error, Is.EqualTo("No overrides to remove."));
+
+            _parameterOverrides.SetEditedProperty(1, "val", MaxSize, out _);
+
+            // out of bounds
+            Assert.That(_parameterOverrides.RemoveOverride(-1, out error), Is.False);
+            Assert.That(error, Is.EqualTo("Attempting to fetch index outside of bounds."));
+
+            Assert.That(_parameterOverrides.RemoveOverride(MaxSize, out error), Is.False);
+            Assert.That(error, Is.EqualTo("Attempting to fetch index outside of bounds."));
+
+            // index in bounds but never overridden
+            Assert.That(_parameterOverrides.RemoveOverride(0, out error), Is.False);
+            Assert.That(error, Is.EqualTo("No overrides to remove."));
+
+            // index was overridden then removed (double-remove)
+            Assert.That(_parameterOverrides.RemoveOverride(1, out error), Is.True);
+            Assert.That(_parameterOverrides.RemoveOverride(1, out error), Is.False);
+            Assert.That(error, Is.EqualTo("No overrides to remove."));
+        }
+
+        [Test]
         public void SetEditedProperty_Errors()
         {
             Assert.That(_parameterOverrides.SetEditedProperty(1, "string", -1, out var error), Is.False);

--- a/Tests/Runtime/ParameterManagerTest.cs
+++ b/Tests/Runtime/ParameterManagerTest.cs
@@ -366,6 +366,39 @@ namespace PocketGems.Parameters
         }
 
         [Test]
+        public void ApplyOverrides_PartialFailure_RevertsSuccessful()
+        {
+            LoadInfos();
+
+            // first edit will succeed, second will fail
+            _mockSubclassBInfo.ReturnEditPropertyError = "some error";
+
+            var success = _parameterManager.ApplyOverrides(JObject.Parse("{\"edit\":" +
+                                                           "[" +
+                                                           "  [\"SubInterfaceAInfo.csv\"," +
+                                                           $"  \"{SubclassAId}\"," +
+                                                           "   \"SomeColumnName\"," +
+                                                           "   \"SomeValue\"]," +
+                                                           "  [\"SubInterfaceBInfo.csv\"," +
+                                                           $"  \"{SubclassBId}\"," +
+                                                           "   \"SomeColumnName2\"," +
+                                                           "   \"SomeValue2\"]" +
+                                                           "]" +
+                                                           "}"), out IReadOnlyList<string> errors);
+            Assert.IsFalse(success);
+            Assert.AreEqual(1, errors.Count);
+
+            // first edit succeeded then was rolled back
+            Assert.AreEqual(1, _mockSubclassAInfo.EditPropertyCalls);
+            Assert.AreEqual(1, _mockSubclassAInfo.RevertEditPropertyCalls);
+            Assert.AreEqual("SomeColumnName", _mockSubclassAInfo.RevertEditPropertyPropertyName);
+
+            // second edit failed — no revert needed
+            Assert.AreEqual(1, _mockSubclassBInfo.EditPropertyCalls);
+            Assert.AreEqual(0, _mockSubclassBInfo.RevertEditPropertyCalls);
+        }
+
+        [Test]
         public void ApplyAndClearOverrides()
         {
             LoadInfos();
@@ -404,6 +437,10 @@ namespace PocketGems.Parameters
             Assert.AreEqual(0, _mockKeyValueStruct.RemoveAllEditCalls);
             Assert.AreEqual("SomeColumnName2", _mockKeyValueStruct.EditPropertyPropertyName);
             Assert.AreEqual("SomeValue2", _mockKeyValueStruct.EditPropertyValue);
+
+            // no reverts on success
+            Assert.AreEqual(0, _mockSubclassAInfo.RevertEditPropertyCalls);
+            Assert.AreEqual(0, _mockKeyValueStruct.RevertEditPropertyCalls);
 
             _parameterManager.ClearAllOverrides();
 

--- a/Tests/Runtime/TestCode/TestClasses.cs
+++ b/Tests/Runtime/TestCode/TestClasses.cs
@@ -6,10 +6,15 @@ using PocketGems.Parameters.Interface;
 public abstract class MockMutableParameter : IMutableParameter
 {
     public int EditPropertyCalls;
+    public int RevertEditPropertyCalls;
     public int RemoveAllEditCalls;
+
     public string EditPropertyPropertyName;
     public string EditPropertyValue;
     public string ReturnEditPropertyError;
+
+    public string RevertEditPropertyPropertyName;
+    public string ReturnRevertEditPropertyError;
 
     public bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error)
     {
@@ -18,6 +23,14 @@ public abstract class MockMutableParameter : IMutableParameter
         EditPropertyValue = value;
         error = ReturnEditPropertyError;
         return string.IsNullOrWhiteSpace(ReturnEditPropertyError);
+    }
+
+    public bool RevertEditedProperty(string propertyName, out string error)
+    {
+        RevertEditPropertyCalls++;
+        RevertEditPropertyPropertyName = propertyName;
+        error = ReturnRevertEditPropertyError;
+        return string.IsNullOrWhiteSpace(ReturnRevertEditPropertyError);
     }
 
     public void RemoveAllEdits() => RemoveAllEditCalls++;
@@ -123,6 +136,8 @@ public class MockTestValidationInfo : IMutableParameter, ITestValidationInfo
 
     public bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error) =>
         throw new System.NotImplementedException();
+    public bool RevertEditedProperty(string propertyName, out string error) =>
+        throw new System.NotImplementedException();
     public void RemoveAllEdits() => throw new System.NotImplementedException();
     public IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager) => throw new System.NotImplementedException();
 }
@@ -135,7 +150,7 @@ public class MockSubBadValidationInfo : IMutableParameter, ITestSubInterfaceInfo
 
     public bool EditProperty(IParameterManager parameterManager, string propertyName, string value, out string error) =>
         throw new System.NotImplementedException();
-
+    public bool RevertEditedProperty(string propertyName, out string error) => throw new System.NotImplementedException();
     public void RemoveAllEdits() => throw new System.NotImplementedException();
     public IMutableParameter CreateLinkedMutableParameter(IParameterManager parameterManager) => throw new System.NotImplementedException();
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.0.5",
+  "version": "5.0.6",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.0.6] - 2026-05-21
### Fixed
- Failed calls to the `IMutableParameterManager.ApplyOverrides()` will now revert any partial overrides upon failure.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
