### PR TITLE
Sort ScriptableObject lists by GUID for deterministic FlatBuffer output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.7] - 2026-06-02
+### Fixed
+- Sort ScriptableObject lists by GUID before building FlatBuffer data so output is deterministic across runs.
+
 ## [5.0.6] - 2026-05-21
 ### Fixed
 - Failed calls to the `IMutableParameterManager.ApplyOverrides()` will now revert any partial overridesn upon failure.

--- a/Editor/DataGeneration/Operations/BuildDataBufferOperation.cs
+++ b/Editor/DataGeneration/Operations/BuildDataBufferOperation.cs
@@ -37,6 +37,10 @@ namespace PocketGems.Parameters.DataGeneration.Operations.Editor
                 var outputPath = Path.Combine(outputDirectory, outputFilename);
 
                 var typeToSoDict = context.ScriptableObjectMetadatas.ToDictionary(kvp => kvp.Key.Type, kvp => kvp.Value);
+
+                // sort by GUID so FlatBuffer output is deterministic across runs
+                foreach (var kvp in typeToSoDict)
+                    kvp.Value.Sort((a, b) => string.Compare(a.GUID, b.GUID, StringComparison.Ordinal));
                 var log = GenerateAndWrite(context, outputPath, typeToSoDict);
                 ParameterDebug.Log(log);
             }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.0.6",
+  "version": "5.0.7",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.0.7] - 2026-06-02
### Fixed
- Sort ScriptableObject lists by GUID before building FlatBuffer data so output is deterministic across runs.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
