### PR TITLE
EditorParams: Restore reflection fallback for pre-TypeCache Unity versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2026-07-27
+### Fixed
+- Restored the reflection-based `EditorParams.FindSingleInterfaceImplementation` fallback for Unity versions without `TypeCache` (pre-2019.2).
+
 ## [5.1.0] - 2026-07-24
 ### Added
 - Generate CSVs on demand via `Pocket Gems → Parameters → Generate CSVs` (or the button in the Config window).

--- a/Runtime/EditorParams.cs
+++ b/Runtime/EditorParams.cs
@@ -1,5 +1,8 @@
 #if UNITY_EDITOR
 using System;
+#if !UNITY_2019_2_OR_NEWER
+using System.Reflection;
+#endif
 using PocketGems.Parameters.AssetLoader;
 using UnityEditor;
 using UnityEngine;
@@ -100,6 +103,7 @@ namespace PocketGems.Parameters
         internal static Type FindSingleInterfaceImplementation(Type searchInterfaceType)
         {
             Type implementationType = null;
+#if UNITY_2019_2_OR_NEWER
             foreach (var type in TypeCache.GetTypesDerivedFrom(searchInterfaceType))
             {
                 if (type.IsAbstract)
@@ -110,7 +114,40 @@ namespace PocketGems.Parameters
                 else
                     Debug.LogError($"Found more than one implementation of {searchInterfaceType}");
             }
+#else
+            AppDomain currentDomain = AppDomain.CurrentDomain;
+            Assembly[] assemblies = currentDomain.GetAssemblies();
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                var assembly = assemblies[i];
+                // GetType() dies when iterating through BrotliSharpLib due to a struct being over 1MB
+                // DynamicProxyGenAssembly2 can hold NSubstitute proxy interfaces which we don't want
+                if (assembly.FullName.StartsWith("BrotliSharpLib") ||
+                    assembly.FullName.StartsWith("DynamicProxyGenAssembly2")
+                    )
+                    continue;
+                var types = assembly.GetTypes();
+                for (int j = 0; j < types.Length; j++)
+                {
+                    var type = types[j];
+                    if (type.IsAbstract)
+                        continue;
+                    var interfaces = type.GetInterfaces();
+                    for (int k = 0; k < interfaces.Length; k++)
+                    {
+                        var interfaceType = interfaces[k];
+                        if (interfaceType != searchInterfaceType)
+                            continue;
 
+                        if (implementationType == null)
+                            implementationType = type;
+                        else
+                            Debug.LogError($"Found more than one implementation of {searchInterfaceType}");
+                        break;
+                    }
+                }
+            }
+#endif
             return implementationType;
         }
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.1.0",
+  "version": "5.1.1",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.1.1] - 2026-07-27
### Fixed
- Restored the reflection-based `EditorParams.FindSingleInterfaceImplementation` fallback for Unity versions without `TypeCache` (pre-2019.2).

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
