### PR TITLE
Various Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - "Open CSV" in the Scriptable Object inspector now offers to generate the CSVs when the file doesn't exist, instead of only logging an error.
 - Compilation fix for Addressables 2.x (Unity 6+), where `BuildScriptVirtualMode` was removed — guarded via a new `ADDRESSABLES_2_0_0_OR_NEWER` version define.
+- Compilation fix for Unity 6000.3+, where the new `UnityEditor.IMGUI.Controls.TreeViewItem<TIdentifier>` made the validation tree view's internal `TreeViewItem<T>` reference ambiguous.
 
 ## [5.1.1] - 2026-07-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.1.2] - 2026-08-05
 ### Fixed
 - "Open CSV" in the Scriptable Object inspector now offers to generate the CSVs when the file doesn't exist, instead of only logging an error.
+- Compilation fix for Addressables 2.x (Unity 6+), where `BuildScriptVirtualMode` was removed — guarded via a new `ADDRESSABLES_2_0_0_OR_NEWER` version define.
 
 ## [5.1.1] - 2026-07-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All package updates & migration steps will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.2] - 2026-08-05
+### Fixed
+- "Open CSV" in the Scriptable Object inspector now offers to generate the CSVs when the file doesn't exist, instead of only logging an error.
+
 ## [5.1.1] - 2026-07-27
 ### Fixed
 - Restored the reflection-based `EditorParams.FindSingleInterfaceImplementation` fallback for Unity versions without `TypeCache` (pre-2019.2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Open CSV" in the Scriptable Object inspector now offers to generate the CSVs when the file doesn't exist, instead of only logging an error.
 - Compilation fix for Addressables 2.x (Unity 6+), where `BuildScriptVirtualMode` was removed — guarded via a new `ADDRESSABLES_2_0_0_OR_NEWER` version define.
 - Compilation fix for Unity 6000.3+, where the new `UnityEditor.IMGUI.Controls.TreeViewItem<TIdentifier>` made the validation tree view's internal `TreeViewItem<T>` reference ambiguous.
+- Syncing a CSV edit that renames an identifier now queues a full regeneration (as deletions already did), so the old identifier's rows don't linger in the previously built parameter data.
 
 ## [5.1.1] - 2026-07-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [5.1.2] - 2026-08-05
+### Changed
+- The "Generate CSVs" menu action now reveals the CSV folder in Finder/Explorer after a successful generation.
 ### Fixed
 - "Open CSV" in the Scriptable Object inspector now offers to generate the CSVs when the file doesn't exist, instead of only logging an error.
 - Compilation fix for Addressables 2.x (Unity 6+), where `BuildScriptVirtualMode` was removed — guarded via a new `ADDRESSABLES_2_0_0_OR_NEWER` version define.

--- a/Editor/DataGeneration/Operations/CheckGenerateDataTypeOperation.cs
+++ b/Editor/DataGeneration/Operations/CheckGenerateDataTypeOperation.cs
@@ -87,8 +87,13 @@ namespace PocketGems.Parameters.DataGeneration.Operations.Editor
             if (settings == null)
                 return;
             var editorDataBuilder = settings.ActivePlayModeDataBuilder;
+#if ADDRESSABLES_2_0_0_OR_NEWER
+            // BuildScriptVirtualMode ("Simulate Groups (advanced)") was removed in Addressables 2.0.
+            bool isUsingRemoteBundles = !(editorDataBuilder is BuildScriptFastMode);
+#else
             bool isUsingRemoteBundles =
                 !(editorDataBuilder is BuildScriptFastMode || editorDataBuilder is BuildScriptVirtualMode);
+#endif
             if (isUsingRemoteBundles)
             {
                 if (context.GenerateDataType == GenerateDataType.CSVDiff)

--- a/Editor/DataGeneration/Operations/ScriptableObjectLoaderOperation.cs
+++ b/Editor/DataGeneration/Operations/ScriptableObjectLoaderOperation.cs
@@ -413,7 +413,20 @@ namespace PocketGems.Parameters.DataGeneration.Operations.Editor
                 // ParameterDebug.LogVerbose($"Matched on GUID [{guid}]: {metadata.ScriptableObject}");
                 // The asset will be renamed (later, from the CSV value) if its current name no longer matches.
                 if (metadata.ScriptableObject != null && metadata.ScriptableObject.name != rowData.Identifier)
+                {
                     counts.Renamed++;
+                    if (!dryRun)
+                    {
+                        /*
+                         * For renamed identifiers, we need to regenerate the whole FlatBuffer again
+                         * after this current run because the old rows will still be in the old FlatBuffer.
+                         *
+                         * We cannot switch to GenerateAll at this point because we still need to update
+                         * the Scriptable Objects from the updated CSV data first.
+                         */
+                        context.GenerateAllAgain = true;
+                    }
+                }
                 else
                     counts.Modified++;
                 if (!dryRun)

--- a/Editor/DataGeneration/PocketGems.Parameters.DataGeneration.Editor.asmdef
+++ b/Editor/DataGeneration/PocketGems.Parameters.DataGeneration.Editor.asmdef
@@ -22,6 +22,11 @@
             "name": "com.unity.addressables",
             "expression": "",
             "define": "ADDRESSABLE_PARAMS"
+        },
+        {
+            "name": "com.unity.addressables",
+            "expression": "2.0.0",
+            "define": "ADDRESSABLES_2_0_0_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Editor/Editor/ParameterScriptableObjectInspector.cs
+++ b/Editor/Editor/ParameterScriptableObjectInspector.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using PocketGems.Parameters.Common.Editor;
 using PocketGems.Parameters.Common.Util.Editor;
+using PocketGems.Parameters.DataGeneration.Operation.Editor;
 using PocketGems.Parameters.Interface;
 using PocketGems.Parameters.Interface.Attributes;
 using PocketGems.Parameters.Validation;
@@ -54,9 +55,26 @@ namespace PocketGems.Parameters.Editor.Editor
 
                 var absoluteCSVPath = Path.Combine(projectPath, relativeCSVPath);
                 if (File.Exists(absoluteCSVPath))
+                {
                     Application.OpenURL($"file://{absoluteCSVPath}");
-                else
-                    ParameterDebug.LogError($"File doesn't exist: {absoluteCSVPath}");
+                }
+                else if (EditorUtility.DisplayDialog("CSV Not Found",
+                             $"The CSV file \"{csvFileName}\" doesn't exist.\n\nWould you like to generate the CSVs now?",
+                             "Yes", "No"))
+                {
+                    EditorParameterDataManager.GenerateData(GenerateDataType.All, out _, generateCSVs: true);
+                    if (File.Exists(absoluteCSVPath))
+                    {
+                        Application.OpenURL($"file://{absoluteCSVPath}");
+                    }
+                    else
+                    {
+                        ParameterDebug.LogError($"File doesn't exist after generating CSVs: {absoluteCSVPath}");
+                        EditorUtility.DisplayDialog("CSV Still Missing",
+                            $"The CSV file \"{csvFileName}\" still doesn't exist after generating CSVs.\n\nThis is likely a bug in the parameters package — please report it.",
+                            "Okay");
+                    }
+                }
             }
             EditorGUILayout.EndHorizontal();
 

--- a/Editor/Editor/ParametersWindow.cs
+++ b/Editor/Editor/ParametersWindow.cs
@@ -34,6 +34,9 @@ namespace PocketGems.Parameters.Editor.Editor
         public static void GenerateCSVs()
         {
             EditorParameterDataManager.GenerateData(GenerateDataType.All, out _, generateCSVs: true);
+            var csvDir = EditorParameterConstants.CSV.Dir;
+            if (Directory.Exists(csvDir) && Directory.GetFiles(csvDir, "*.csv").Length > 0)
+                EditorUtility.RevealInFinder(csvDir);
         }
 
         [MenuItem(MenuItemConstants.RegenerateCodePath, false, MenuItemConstants.RegenerateCodePriority)]

--- a/Editor/Editor/Validation/ValidationTreeView.cs
+++ b/Editor/Editor/Validation/ValidationTreeView.cs
@@ -7,6 +7,8 @@ using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.TestTools;
+// alias to disambiguate from UnityEditor.IMGUI.Controls.TreeViewItem<TIdentifier> introduced in Unity 6000.3
+using ValidationTreeViewItem = PocketGems.Parameters.Editor.Validation.TreeDataModel.Editor.TreeViewItem<PocketGems.Parameters.Editor.Validation.Editor.ValidationTreeElement>;
 
 /// <summary>
 /// Modified from Unity's provided example:
@@ -105,12 +107,12 @@ namespace PocketGems.Parameters.Editor.Validation.Editor
 
             if (item == null)
                 return;
-            OnClickedTreeElement?.Invoke(((TreeViewItem<ValidationTreeElement>)item).data);
+            OnClickedTreeElement?.Invoke(((ValidationTreeViewItem)item).data);
         }
 
         protected override void RowGUI(RowGUIArgs args)
         {
-            var item = (TreeViewItem<ValidationTreeElement>)args.item;
+            var item = (ValidationTreeViewItem)args.item;
 
             for (int i = 0; i < args.GetNumVisibleColumns(); ++i)
             {
@@ -118,7 +120,7 @@ namespace PocketGems.Parameters.Editor.Validation.Editor
             }
         }
 
-        void CellGUI(Rect cellRect, TreeViewItem<ValidationTreeElement> item, Columns column, ref RowGUIArgs args)
+        void CellGUI(Rect cellRect, ValidationTreeViewItem item, Columns column, ref RowGUIArgs args)
         {
             // Center cell rect vertically (makes it easier to place controls, icons etc in the cells)
             CenterRectUsingSingleLineHeight(ref cellRect);

--- a/Runtime/AssetLoader/EditorAddressablesParameterAssetLoader.cs
+++ b/Runtime/AssetLoader/EditorAddressablesParameterAssetLoader.cs
@@ -40,7 +40,12 @@ namespace PocketGems.Parameters.AssetLoader
              */
             var settings = AddressableAssetSettingsDefaultObject.Settings;
             var dataBuilder = settings.ActivePlayModeDataBuilder;
+#if ADDRESSABLES_2_0_0_OR_NEWER
+            // BuildScriptVirtualMode ("Simulate Groups (advanced)") was removed in Addressables 2.0.
+            var isUsingBundledAssets = !(dataBuilder is BuildScriptFastMode);
+#else
             var isUsingBundledAssets = !(dataBuilder is BuildScriptFastMode || dataBuilder is BuildScriptVirtualMode);
+#endif
             if (isUsingBundledAssets)
                 return;
 

--- a/Runtime/PocketGems.Parameters.Runtime.asmdef
+++ b/Runtime/PocketGems.Parameters.Runtime.asmdef
@@ -20,6 +20,11 @@
             "name": "com.unity.addressables",
             "expression": "",
             "define": "ADDRESSABLE_PARAMS"
+        },
+        {
+            "name": "com.unity.addressables",
+            "expression": "2.0.0",
+            "define": "ADDRESSABLES_2_0_0_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Pocket Gems",
     "url": "https://www.pocketgems.com/"
   },
-  "version": "5.1.1",
+  "version": "5.1.2",
   "codegen": "0.0.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.2",


### PR DESCRIPTION
# Change Log
## [5.1.2] - 2026-08-05
### Changed
- The "Generate CSVs" menu action now reveals the CSV folder in Finder/Explorer after a successful generation.
### Fixed
- "Open CSV" in the Scriptable Object inspector now offers to generate the CSVs when the file doesn't exist, instead of only logging an error.
- Compilation fix for Addressables 2.x (Unity 6+), where `BuildScriptVirtualMode` was removed — guarded via a new `ADDRESSABLES_2_0_0_OR_NEWER` version define.
- Compilation fix for Unity 6000.3+, where the new `UnityEditor.IMGUI.Controls.TreeViewItem<TIdentifier>` made the validation tree view's internal `TreeViewItem<T>` reference ambiguous.
- Syncing a CSV edit that renames an identifier now queues a full regeneration (as deletions already did), so the old identifier's rows don't linger in the previously built parameter data.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
